### PR TITLE
neovim 0.12

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -63,27 +63,6 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -122,44 +101,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "neovim-nightly-overlay": {
-      "inputs": {
-        "flake-parts": "flake-parts_2",
-        "neovim-src": "neovim-src",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774915815,
-        "narHash": "sha256-LocQzkSjVS4G0AKMBiEIVdBKCNTMZXQFjQMWFId4Jpg=",
-        "owner": "nix-community",
-        "repo": "neovim-nightly-overlay",
-        "rev": "9001416dc5d0ca24c8e4b5a44bfe7cd6fbeb1dd1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "neovim-nightly-overlay",
-        "type": "github"
-      }
-    },
-    "neovim-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1774915197,
-        "narHash": "sha256-yor+eo8CVi7wBp7CjAMQnVoK+m197gsl7MvUzaqicns=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "dbc4800dda2b0dc3290dc79955f857256e0694e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "neovim",
-        "repo": "neovim",
         "type": "github"
       }
     },
@@ -260,7 +201,6 @@
         "agenix": "agenix",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager_2",
-        "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nix-darwin": "nix-darwin",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs",

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -12,10 +12,6 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    neovim-nightly-overlay = {
-      url = "github:nix-community/neovim-nightly-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     nix-darwin = {
       url = "github:nix-darwin/nix-darwin/master";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -71,16 +67,8 @@
         ];
 
         perSystem =
-          { system, ... }:
-          let
-            pkgs = import inputs.nixpkgs {
-              inherit system;
-              overlays = [ inputs.neovim-nightly-overlay.overlays.default ];
-            };
-          in
+          { pkgs, ... }:
           {
-            _module.args.pkgs = pkgs;
-
             devShells = {
               default = pkgs.mkShell {
                 packages = with pkgs; [

--- a/nix/modules/hosts/aaron/default.nix
+++ b/nix/modules/hosts/aaron/default.nix
@@ -10,7 +10,6 @@ let
     home-manager
     pronto
     agenix
-    neovim-nightly-overlay
     ;
 in
 {
@@ -18,7 +17,6 @@ in
     specialArgs = { inherit self pronto agenix; };
     modules = [
       ./configuration.nix
-      { nixpkgs.overlays = [ neovim-nightly-overlay.overlays.default ]; }
       nix-index-database.darwinModules.nix-index
       home-manager.darwinModules.home-manager
       agenix.darwinModules.default

--- a/nix/modules/hosts/leod/default.nix
+++ b/nix/modules/hosts/leod/default.nix
@@ -10,7 +10,6 @@ let
     home-manager
     pronto
     agenix
-    neovim-nightly-overlay
     ;
 in
 {
@@ -18,7 +17,6 @@ in
     specialArgs = { inherit self pronto agenix; };
     modules = [
       ./configuration.nix
-      { nixpkgs.overlays = [ neovim-nightly-overlay.overlays.default ]; }
       nix-index-database.nixosModules.default
       home-manager.nixosModules.home-manager
       agenix.nixosModules.default

--- a/nix/modules/hosts/tower/default.nix
+++ b/nix/modules/hosts/tower/default.nix
@@ -10,7 +10,6 @@ let
     home-manager
     pronto
     agenix
-    neovim-nightly-overlay
     ;
 in
 {
@@ -18,7 +17,6 @@ in
     specialArgs = { inherit self pronto agenix; };
     modules = [
       ./configuration.nix
-      { nixpkgs.overlays = [ neovim-nightly-overlay.overlays.default ]; }
       nix-index-database.nixosModules.default
       home-manager.nixosModules.home-manager
       agenix.nixosModules.default

--- a/nix/pkgs/neovim-wrapped.nix
+++ b/nix/pkgs/neovim-wrapped.nix
@@ -4,7 +4,7 @@
   symlinkJoin,
   makeWrapper,
   runCommandLocal,
-  neovim,
+  neovim-unwrapped,
   lib,
   bash-language-server,
   black,
@@ -33,8 +33,20 @@
   vscode-langservers-extracted,
   wl-clipboard,
   with-git-wrapped ? true,
+  fetchFromGitHub,
+  wrapNeovim,
 }:
 let
+  neovim-pinned = wrapNeovim (neovim-unwrapped.overrideAttrs (_old: {
+    version = "0.12.0";
+    src = fetchFromGitHub {
+      owner = "neovim";
+      repo = "neovim";
+      rev = "v0.12.0";
+      hash = "sha256-uWhrGAwQ2nnAkyJ46qGkYxJ5K1jtyUIQOAVu3yTlquk=";
+    };
+  })) { };
+
   pbcopy = runCommandLocal "pbcopy" { } ''
     mkdir -p $out/bin
     ln -s /usr/bin/pbcopy $out/bin/pbcopy
@@ -86,7 +98,7 @@ in
 symlinkJoin {
   name = "neovim-wrapped";
   nativeBuildInputs = [ makeWrapper ];
-  paths = [ neovim ];
+  paths = [ neovim-pinned ];
   meta.mainProgram = "nvim";
   postBuild = ''
     wrapProgram $out/bin/nvim \


### PR DESCRIPTION
- **nix: remove neovim-nightly-overlay from flake and hosts**
- **neovim-wrapped: pin to neovim 0.12.0 release**
