### PR TITLE
zen browser copilot

### DIFF
--- a/nix/browser-config.nix
+++ b/nix/browser-config.nix
@@ -1,5 +1,5 @@
 { lib }:
-let
+{
   renderDefaultPrefs =
     settings:
     builtins.concatStringsSep "\n" (
@@ -37,7 +37,4 @@ let
     "browser.ctrlTab.sortByRecentlyUsed" = true;
     "media.videocontrols.picture-in-picture.enable-when-switching-tabs.enabled" = true;
   };
-in
-{
-  inherit renderDefaultPrefs sharedPolicies sharedSettings;
 }

--- a/nix/browser-config.nix
+++ b/nix/browser-config.nix
@@ -1,0 +1,50 @@
+let
+  renderPrefValue =
+    value:
+    if builtins.isBool value then
+      if value then "true" else "false"
+    else if builtins.isInt value then
+      toString value
+    else
+      builtins.toJSON value;
+
+  renderDefaultPrefs =
+    settings:
+    builtins.concatStringsSep "\n" (
+      map (name: "defaultPref(${builtins.toJSON name}, ${renderPrefValue settings.${name}});") (
+        builtins.attrNames settings
+      )
+    );
+
+  sharedPolicies = {
+    PasswordManagerEnabled = false;
+    SearchEngines = {
+      Default = "DuckDuckGo";
+    };
+    ExtensionSettings = {
+      "uBlock0@raymondhill.net" = {
+        install_url = "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi";
+        installation_mode = "force_installed";
+        default_area = "menupanel";
+      };
+      "{446900e4-71c2-419f-a6a7-df9c091e268b}" = {
+        install_url = "https://addons.mozilla.org/firefox/downloads/latest/bitwarden-password-manager/latest.xpi";
+        installation_mode = "force_installed";
+        default_area = "navbar";
+      };
+      "{d7742d87-e61d-4b78-b8a1-b469842139fa}" = {
+        install_url = "https://addons.mozilla.org/firefox/downloads/latest/vimium-ff/latest.xpi";
+        installation_mode = "force_installed";
+        default_area = "menupanel";
+      };
+    };
+  };
+
+  sharedSettings = {
+    "browser.ctrlTab.sortByRecentlyUsed" = true;
+    "media.videocontrols.picture-in-picture.enable-when-switching-tabs.enabled" = true;
+  };
+in
+{
+  inherit renderDefaultPrefs sharedPolicies sharedSettings;
+}

--- a/nix/browser-config.nix
+++ b/nix/browser-config.nix
@@ -1,23 +1,16 @@
+{ lib }:
 let
-  renderPrefValue =
-    value:
-    if builtins.isBool value then
-      if value then "true" else "false"
-    else if builtins.isInt value then
-      toString value
-    else
-      builtins.toJSON value;
-
   renderDefaultPrefs =
     settings:
     builtins.concatStringsSep "\n" (
-      map (name: "defaultPref(${builtins.toJSON name}, ${renderPrefValue settings.${name}});") (
+      map (name: "defaultPref(${lib.strings.toJSON name}, ${lib.strings.toJSON settings.${name}});") (
         builtins.attrNames settings
       )
     );
 
   sharedPolicies = {
     PasswordManagerEnabled = false;
+    DontCheckDefaultBrowser = true;
     SearchEngines = {
       Default = "DuckDuckGo";
     };

--- a/nix/browser-config.nix
+++ b/nix/browser-config.nix
@@ -2,10 +2,10 @@
 {
   renderDefaultPrefs =
     settings:
-    builtins.concatStringsSep "\n" (
-      map (name: "defaultPref(${lib.strings.toJSON name}, ${lib.strings.toJSON settings.${name}});") (
-        builtins.attrNames settings
-      )
+    lib.concatLines (
+      lib.mapAttrsToList (
+        name: value: "defaultPref(${lib.strings.toJSON name}, ${lib.strings.toJSON value});"
+      ) settings
     );
 
   sharedPolicies = {

--- a/nix/browser-config.nix
+++ b/nix/browser-config.nix
@@ -4,7 +4,7 @@
     settings:
     lib.concatLines (
       lib.mapAttrsToList (
-        name: value: "defaultPref(${lib.strings.toJSON name}, ${lib.strings.toJSON value});"
+        name: value: "lockPref(${lib.strings.toJSON name}, ${lib.strings.toJSON value});"
       ) settings
     );
 

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -204,7 +204,8 @@
         "nix-darwin": "nix-darwin",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs",
-        "pronto": "pronto"
+        "pronto": "pronto",
+        "zen-browser": "zen-browser"
       }
     },
     "systems": {
@@ -219,6 +220,26 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "zen-browser": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775710180,
+        "narHash": "sha256-sCokvdNvl8zIzsnjgG0TN5h3RUI7GJyWW9ErfmEj0rM=",
+        "owner": "youwen5",
+        "repo": "zen-browser-flake",
+        "rev": "2c138beb648d1cbbfae76695a8230ee04e4db25a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "youwen5",
+        "repo": "zen-browser-flake",
         "type": "github"
       }
     }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -36,6 +36,10 @@
       url = "github:nix-community/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    zen-browser = {
+      url = "github:youwen5/zen-browser-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/nix/modules/home/common.nix
+++ b/nix/modules/home/common.nix
@@ -9,7 +9,7 @@ _: {
     let
       symlink = path: config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/setup/${path}";
 
-      browserConfig = import ../../browser-config.nix;
+      browserConfig = import ../../browser-config.nix { inherit lib; };
     in
     {
       home = {

--- a/nix/modules/home/common.nix
+++ b/nix/modules/home/common.nix
@@ -8,6 +8,8 @@ _: {
     }:
     let
       symlink = path: config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/setup/${path}";
+
+      browserConfig = import ../../browser-config.nix;
     in
     {
       home = {
@@ -40,36 +42,12 @@ _: {
         firefox = {
           enable = true;
           nativeMessagingHosts = lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.firefoxpwa ];
-          policies = {
-            PasswordManagerEnabled = false;
-            SearchEngines = {
-              Default = "DuckDuckGo";
-            };
-            ExtensionSettings = {
-              "uBlock0@raymondhill.net" = {
-                install_url = "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi";
-                installation_mode = "force_installed";
-                default_area = "menupanel";
-              };
-              "{446900e4-71c2-419f-a6a7-df9c091e268b}" = {
-                install_url = "https://addons.mozilla.org/firefox/downloads/latest/bitwarden-password-manager/latest.xpi";
-                installation_mode = "force_installed";
-                default_area = "navbar";
-              };
-              "{d7742d87-e61d-4b78-b8a1-b469842139fa}" = {
-                install_url = "https://addons.mozilla.org/firefox/downloads/latest/vimium-ff/latest.xpi";
-                installation_mode = "force_installed";
-                default_area = "menupanel";
-              };
-            };
-          };
+          policies = browserConfig.sharedPolicies;
           profiles.default = {
-            settings = {
+            settings = browserConfig.sharedSettings // {
               # Enable the new sidebar + vertical tabs via user prefs (policies block these).
               "sidebar.revamp" = true;
               "sidebar.verticalTabs" = true;
-              "browser.ctrlTab.sortByRecentlyUsed" = true;
-              "media.videocontrols.picture-in-picture.enable-when-switching-tabs.enabled" = true;
             };
           };
         };

--- a/nix/modules/nixos-workstation.nix
+++ b/nix/modules/nixos-workstation.nix
@@ -92,7 +92,7 @@ _: {
             creme
             lock-suspend
             check-bt-profile
-            zen-browser
+            zen-browser-wrapped
           ];
 
           externalPackages = with pkgs; [

--- a/nix/modules/nixos-workstation.nix
+++ b/nix/modules/nixos-workstation.nix
@@ -112,6 +112,7 @@ _: {
             usbutils # provides lsusb
             whatsapp-electron
             wl-clipboard
+            self.inputs.zen-browser.packages.${system}.default
           ];
         in
         customPackages ++ externalPackages;

--- a/nix/modules/nixos-workstation.nix
+++ b/nix/modules/nixos-workstation.nix
@@ -8,6 +8,14 @@ _: {
     }:
     let
       inherit (pkgs.stdenv.hostPlatform) system;
+
+      zen-browser = pkgs.wrapFirefox self.inputs.zen-browser.packages.${system}.zen-browser-unwrapped {
+        extraPolicies = {
+          SearchEngines = {
+            Default = "DuckDuckGo";
+          };
+        };
+      };
     in
     {
       imports = [
@@ -92,6 +100,7 @@ _: {
             creme
             lock-suspend
             check-bt-profile
+            zen-browser
           ];
 
           externalPackages = with pkgs; [
@@ -112,7 +121,6 @@ _: {
             usbutils # provides lsusb
             whatsapp-electron
             wl-clipboard
-            self.inputs.zen-browser.packages.${system}.default
           ];
         in
         customPackages ++ externalPackages;

--- a/nix/modules/nixos-workstation.nix
+++ b/nix/modules/nixos-workstation.nix
@@ -8,14 +8,6 @@ _: {
     }:
     let
       inherit (pkgs.stdenv.hostPlatform) system;
-
-      zen-browser = pkgs.wrapFirefox self.inputs.zen-browser.packages.${system}.zen-browser-unwrapped {
-        extraPolicies = {
-          SearchEngines = {
-            Default = "DuckDuckGo";
-          };
-        };
-      };
     in
     {
       imports = [

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -9,7 +9,6 @@ _: {
     }:
     {
       packages = {
-        zen-browser-wrapped = pkgs.callPackage ./zen-browser-wrapped { inherit inputs'; };
         git-wrapped = pkgs.callPackage ./git-wrapped {
           # inherit self';
         };
@@ -40,6 +39,8 @@ _: {
         finder = pkgs.callPackage ./finder { };
       }
       // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+        # TODO: Move to general
+        zen-browser-wrapped = pkgs.callPackage ./zen-browser-wrapped { inherit inputs'; };
         toggle-cpu-governor = pkgs.callPackage ./toggle-cpu-governor { };
         waybar-wrapped = pkgs.callPackage ./waybar-wrapped { inherit self'; };
         waybar-wrapped-dev = pkgs.callPackage ./waybar-wrapped {

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -9,6 +9,7 @@ _: {
     }:
     {
       packages = {
+        zen-browser-wrapped = pkgs.callPackage ./zen-browser-wrapped { inherit inputs'; };
         git-wrapped = pkgs.callPackage ./git-wrapped {
           # inherit self';
         };

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -39,7 +39,6 @@ _: {
         finder = pkgs.callPackage ./finder { };
       }
       // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-        # TODO: Move to general
         zen-browser-wrapped = pkgs.callPackage ./zen-browser-wrapped { inherit inputs'; };
         toggle-cpu-governor = pkgs.callPackage ./toggle-cpu-governor { };
         waybar-wrapped = pkgs.callPackage ./waybar-wrapped { inherit self'; };

--- a/nix/pkgs/niri-wrapped/config.kdl
+++ b/nix/pkgs/niri-wrapped/config.kdl
@@ -321,12 +321,12 @@ window-rule {
     default-column-width {}
 }
 
-// Open the Firefox picture-in-picture player as floating by default.
+// Open the Firefox/Zen picture-in-picture player as floating by default.
 window-rule {
     // This app-id regular expression will work for both:
     // - host Firefox (app-id is "firefox")
     // - Flatpak Firefox (app-id is "org.mozilla.firefox")
-    match app-id=r#"firefox$"# title="^Picture-in-Picture$"
+    match app-id=r#"(firefox|zen)$"# title="^Picture-in-Picture$"
     open-floating true
 }
 

--- a/nix/pkgs/zen-browser-wrapped/default.nix
+++ b/nix/pkgs/zen-browser-wrapped/default.nix
@@ -1,6 +1,10 @@
-{ inputs', wrapFirefox }:
+{
+  inputs',
+  wrapFirefox,
+  lib,
+}:
 let
-  browserConfig = import ../../browser-config.nix;
+  browserConfig = import ../../browser-config.nix { inherit lib; };
 in
 wrapFirefox inputs'.zen-browser.packages.zen-browser-unwrapped {
   extraPrefs = /* javascript */ ''
@@ -12,7 +16,5 @@ wrapFirefox inputs'.zen-browser.packages.zen-browser-unwrapped {
       }
     )}
   '';
-  extraPolicies = browserConfig.sharedPolicies // {
-    DontCheckDefaultBrowser = true;
-  };
+  extraPolicies = browserConfig.sharedPolicies;
 }

--- a/nix/pkgs/zen-browser-wrapped/default.nix
+++ b/nix/pkgs/zen-browser-wrapped/default.nix
@@ -1,6 +1,12 @@
 { inputs', wrapFirefox }:
 wrapFirefox inputs'.zen-browser.packages.zen-browser-unwrapped {
-  extraPrefs = ''
+  extraPrefs = /* javascript */ ''
+    defaultPref("browser.ctrlTab.sortByRecentlyUsed", true);
+    defaultPref(
+      "media.videocontrols.picture-in-picture.enable-when-switching-tabs.enabled",
+      true,
+    );
+
     defaultPref("zen.theme.content-element-separation", 4);
     defaultPref("zen.theme.border-radius", 12);
   '';

--- a/nix/pkgs/zen-browser-wrapped/default.nix
+++ b/nix/pkgs/zen-browser-wrapped/default.nix
@@ -1,0 +1,8 @@
+{ inputs', wrapFirefox }:
+wrapFirefox inputs'.zen-browser.packages.zen-browser-unwrapped {
+  extraPolicies = {
+    SearchEngines = {
+      Default = "DuckDuckGo";
+    };
+  };
+}

--- a/nix/pkgs/zen-browser-wrapped/default.nix
+++ b/nix/pkgs/zen-browser-wrapped/default.nix
@@ -1,42 +1,18 @@
 { inputs', wrapFirefox }:
+let
+  browserConfig = import ../../browser-config.nix;
+in
 wrapFirefox inputs'.zen-browser.packages.zen-browser-unwrapped {
   extraPrefs = /* javascript */ ''
-    defaultPref("browser.ctrlTab.sortByRecentlyUsed", true);
-    defaultPref(
-      "media.videocontrols.picture-in-picture.enable-when-switching-tabs.enabled",
-      true,
-    );
-
-    defaultPref("zen.theme.content-element-separation", 4);
-    defaultPref("zen.theme.border-radius", 12);
+    ${browserConfig.renderDefaultPrefs (
+      browserConfig.sharedSettings
+      // {
+        "zen.theme.content-element-separation" = 4;
+        "zen.theme.border-radius" = 12;
+      }
+    )}
   '';
-  extraPolicies = {
-    PasswordManagerEnabled = false;
-
+  extraPolicies = browserConfig.sharedPolicies // {
     DontCheckDefaultBrowser = true;
-
-    SearchEngines = {
-      Default = "DuckDuckGo";
-    };
-
-    ExtensionSettings = {
-      "uBlock0@raymondhill.net" = {
-        install_url = "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi";
-        installation_mode = "force_installed";
-        default_area = "menupanel";
-      };
-
-      "{446900e4-71c2-419f-a6a7-df9c091e268b}" = {
-        install_url = "https://addons.mozilla.org/firefox/downloads/latest/bitwarden-password-manager/latest.xpi";
-        installation_mode = "force_installed";
-        default_area = "navbar";
-      };
-
-      "{d7742d87-e61d-4b78-b8a1-b469842139fa}" = {
-        install_url = "https://addons.mozilla.org/firefox/downloads/latest/vimium-ff/latest.xpi";
-        installation_mode = "force_installed";
-        default_area = "menupanel";
-      };
-    };
   };
 }

--- a/nix/pkgs/zen-browser-wrapped/default.nix
+++ b/nix/pkgs/zen-browser-wrapped/default.nix
@@ -1,9 +1,32 @@
 { inputs', wrapFirefox }:
 wrapFirefox inputs'.zen-browser.packages.zen-browser-unwrapped {
   extraPolicies = {
+    PasswordManagerEnabled = false;
+
     DontCheckDefaultBrowser = true;
+
     SearchEngines = {
       Default = "DuckDuckGo";
+    };
+
+    ExtensionSettings = {
+      "uBlock0@raymondhill.net" = {
+        install_url = "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi";
+        installation_mode = "force_installed";
+        default_area = "menupanel";
+      };
+
+      "{446900e4-71c2-419f-a6a7-df9c091e268b}" = {
+        install_url = "https://addons.mozilla.org/firefox/downloads/latest/bitwarden-password-manager/latest.xpi";
+        installation_mode = "force_installed";
+        default_area = "navbar";
+      };
+
+      "{d7742d87-e61d-4b78-b8a1-b469842139fa}" = {
+        install_url = "https://addons.mozilla.org/firefox/downloads/latest/vimium-ff/latest.xpi";
+        installation_mode = "force_installed";
+        default_area = "menupanel";
+      };
     };
   };
 }

--- a/nix/pkgs/zen-browser-wrapped/default.nix
+++ b/nix/pkgs/zen-browser-wrapped/default.nix
@@ -1,6 +1,7 @@
 { inputs', wrapFirefox }:
 wrapFirefox inputs'.zen-browser.packages.zen-browser-unwrapped {
   extraPolicies = {
+    DontCheckDefaultBrowser = true;
     SearchEngines = {
       Default = "DuckDuckGo";
     };

--- a/nix/pkgs/zen-browser-wrapped/default.nix
+++ b/nix/pkgs/zen-browser-wrapped/default.nix
@@ -1,5 +1,9 @@
 { inputs', wrapFirefox }:
 wrapFirefox inputs'.zen-browser.packages.zen-browser-unwrapped {
+  extraPrefs = ''
+    defaultPref("zen.theme.content-element-separation", 4);
+    defaultPref("zen.theme.border-radius", 12);
+  '';
   extraPolicies = {
     PasswordManagerEnabled = false;
 

--- a/nix/pkgs/zen-browser-wrapped/default.nix
+++ b/nix/pkgs/zen-browser-wrapped/default.nix
@@ -7,7 +7,7 @@ let
   browserConfig = import ../../browser-config.nix { inherit lib; };
 in
 wrapFirefox inputs'.zen-browser.packages.zen-browser-unwrapped {
-  extraPrefs = /* javascript */ ''
+  extraPrefs = ''
     ${browserConfig.renderDefaultPrefs (
       browserConfig.sharedSettings
       // {


### PR DESCRIPTION
- **add zen-browser to flake inputs and workstation pkgs**
- **add zen-browser with ddg default, refactor pkg source**
- **move zen-browser policy to zen-browser-wrapped pkg**
- **set DontCheckDefaultBrowser policy for zen-browser**
- **add forced extension installs to zen-browser policy**
- **set content separation and border radius prefs**
- **support zen-browser PiP floating & add PiP tab switch prefs**
- **use zen-browser-wrapped in home-manager packages list**
- **move zen-browser-wrapped to Linux-only packages section**
- **refactor browser prefs & policies to shared config module**
- **refactor browser-config to use lib.strings.toJSON**
- **migrate browser-config.nix to attrset style export**
