### PR TITLE
feat: add package diff summary to flake update PR

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -18,8 +18,40 @@ jobs:
 
       - uses: DeterminateSystems/determinate-nix-action@v3
 
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
+
+      - uses: cachix/cachix-action@v17
+        with:
+          name: soft-nix
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build pre-update system (leod)
+        run: |
+          nix build ./nix#nixosConfigurations.leod.config.system.build.toplevel \
+            --accept-flake-config \
+            --no-link \
+            --print-out-paths > /tmp/before
+
       - name: Update flake inputs
         run: nix flake update --flake ./nix --accept-flake-config
+
+      - name: Build post-update system (leod)
+        run: |
+          nix build ./nix#nixosConfigurations.leod.config.system.build.toplevel \
+            --accept-flake-config \
+            --no-link \
+            --print-out-paths > /tmp/after
+
+      - name: Compute package diff
+        id: diff
+        run: |
+          {
+            echo "diff<<EOF"
+            nix store diff-closures "$(cat /tmp/before)" "$(cat /tmp/after)"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
@@ -30,6 +62,10 @@ jobs:
           body: |
             Automated flake input update.
 
-            Review the `flake.lock` diff and merge when CI passes.
+            ## Package changes (leod)
+
+            ```
+            ${{ steps.diff.outputs.diff }}
+            ```
           branch: flake-update
           delete-branch: true

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Free disk space
         run: |
+          df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /opt/hostedtoolcache/CodeQL /usr/local/share/boost \
             "$AGENT_TOOLSDIRECTORY"

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -14,6 +14,13 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY"
+          df -h /
+
       - uses: actions/checkout@v6
 
       - uses: DeterminateSystems/determinate-nix-action@v3


### PR DESCRIPTION
## Summary

- Adds Cachix and magic-nix-cache setup to the flake update workflow
- Builds the `leod` system before and after `nix flake update`
- Runs `nix store diff-closures` to compute package version changes
- Includes the diff in the PR body

## Test plan

- [ ] Trigger the "Update Flake Inputs" workflow manually from this branch via `workflow_dispatch`
- [ ] Verify the resulting PR body contains a package diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)