### PR TITLE
chore: update flake inputs

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777196875,
-        "narHash": "sha256-6M/rTHxFRdKJ6WZYxrCl68qIyh3BvjWBmYC7Vufolbg=",
+        "lastModified": 1777389590,
+        "narHash": "sha256-HWbn7WASXsXGADiBDt6/k9U/HpGBEmoeqIOzrf+z2HE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "38bf0202cae280174cbb80fc24a63978f16333f7",
+        "rev": "8ec5a714dbbeb3fda00bd9758175555ebbad4d07",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777092705,
-        "narHash": "sha256-qKMvM2+eKusg6H6lG2bwDdFjNi1XfEjdLD5xIt8ZgFs=",
+        "lastModified": 1777352968,
+        "narHash": "sha256-BZ+BHCINHSyyCOWo4pCJQU4T994iZLiw7lgFMNw+W9k=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "10f5c809db4f8e7badb6d505924ebbaaeefda4e4",
+        "rev": "bebce586893c7d441edd6cf9cf2cf62a1799361e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake input update.

## Package changes (leod)

```diff
aquamarine: 0.10.0 → 0.11.0, [31;1m17.8 KiB[0m
+boringssl: 0.20260413.0 added, [31;1m3.4 MiB[0m
chromium: 147.0.7727.101 → 147.0.7727.116
chromium-unwrapped: 147.0.7727.101 → 147.0.7727.116, [31;1m11.1 KiB[0m
claude-code: 2.1.112 → 2.1.119, [31;1m154.1 MiB[0m
codex: 0.122.0 → 0.125.0, [31;1m15.6 MiB[0m
deno: 2.7.12 → 2.7.13, [32;1m-255.0 KiB[0m
discord: 0.0.130 → 0.0.134, [32;1m-191.6 KiB[0m
electron: 40.8.5, 41.2.0 → 40.9.2, 41.3.0
electron-unwrapped: 40.8.5, 41.2.0 → 40.9.2, 41.3.0, [31;1m360.3 KiB[0m
firefox: [32;1m-13.0 KiB[0m
firefox-unwrapped: [32;1m-267.9 KiB[0m
firefoxpwa-unwrapped: [32;1m-267.9 KiB[0m
fzf: 0.71.0 → 0.72.0, [31;1m22.5 KiB[0m
gh: 2.90.0 → 2.91.0, [31;1m148.7 KiB[0m
google-chrome: 147.0.7727.101 → 147.0.7727.116, [31;1m1.2 MiB[0m
home-manager: 0-unstable-2026-04-14 → 0-unstable-2026-04-24, [31;1m102.3 KiB[0m
hypridle: [32;1m-17.4 KiB[0m
hyprland: [32;1m-131.4 KiB[0m
hyprlock: [32;1m-35.6 KiB[0m
hyprpaper: [32;1m-31.7 KiB[0m
hyprtoolkit: [32;1m-36.5 KiB[0m
hyprwire: 0.3.0 → 0.3.1, [31;1m9.5 KiB[0m
libphonenumber: 9.0.28 → 9.0.29, [31;1m25.6 KiB[0m
neovim: 0.12.1 → 0.12.2
neovim-unwrapped: 0.12.1 → 0.12.2, [31;1m19.4 KiB[0m
nh: 4.3.1 → 4.3.2
nh-unwrapped: 4.3.1 → 4.3.2, [31;1m10.5 KiB[0m
niri: 25.11 → 26.04, [32;1m-597.0 KiB[0m
nix-index: 0.1.9-unstable-2026-02-05 → 0.1.9-unstable-2026-04-20, [31;1m4.4 MiB[0m
nix-index-with-full-db: 0.1.9-unstable-2026-02-05 → 0.1.9-unstable-2026-04-20
nixos-manual: [31;1m24.8 KiB[0m
nixos-system-leod: 26.05.20260422.0726a0e → 26.05.20260427.1c3fe55
nss: 3.123 → 3.123.1
ollama: 0.21.0 → 0.21.1, [32;1m-21.1 KiB[0m
opencode: 1.14.19 → 1.14.25, [31;1m377.9 KiB[0m
pnpm: 10.33.0 → 10.33.2, [31;1m26.0 KiB[0m
signal-desktop: [32;1m-2.4 MiB[0m
source: [31;1m609.4 KiB[0m
telegram-desktop: 6.7.5 → 6.7.6, [31;1m656.6 KiB[0m
tree-sitter-c-neovim: 0.12.1 → 0.12.2
tree-sitter-lua-neovim: 0.12.1 → 0.12.2
tree-sitter-markdown-neovim: 0.12.1 → 0.12.2
tree-sitter-markdown_inline-neovim: 0.12.1 → 0.12.2
tree-sitter-query-neovim: 0.12.1 → 0.12.2
tree-sitter-vim-neovim: 0.12.1 → 0.12.2
tree-sitter-vimdoc-neovim: 0.12.1 → 0.12.2
vimplugin-conform.nvim: 9.1.0-unstable-2026-03-10 → 9.1.0-unstable-2026-04-23
vimplugin-octo.nvim: 0-unstable-2026-04-16 → 0-unstable-2026-04-22, [31;1m12.7 KiB[0m
zen: 1.19.9b → 1.19.10b, [31;1m56.1 KiB[0m
zen-browser-unwrapped: 1.19.9b → 1.19.10b, [31;1m64.3 KiB[0m
```