### PR TITLE
chore: update flake inputs

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777196875,
-        "narHash": "sha256-6M/rTHxFRdKJ6WZYxrCl68qIyh3BvjWBmYC7Vufolbg=",
+        "lastModified": 1777411657,
+        "narHash": "sha256-P7XjzOo8Cbuj5eBSO1LaQ1hOy3ir8rtUB64EFZ6kKiQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "38bf0202cae280174cbb80fc24a63978f16333f7",
+        "rev": "af59809e9413ec8adb9597a8636491af356fe525",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777092705,
-        "narHash": "sha256-qKMvM2+eKusg6H6lG2bwDdFjNi1XfEjdLD5xIt8ZgFs=",
+        "lastModified": 1777352968,
+        "narHash": "sha256-BZ+BHCINHSyyCOWo4pCJQU4T994iZLiw7lgFMNw+W9k=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "10f5c809db4f8e7badb6d505924ebbaaeefda4e4",
+        "rev": "bebce586893c7d441edd6cf9cf2cf62a1799361e",
         "type": "github"
       },
       "original": {

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -201,6 +201,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-darwin-pins": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1774748309,
@@ -246,6 +262,7 @@
         "nix-darwin": "nix-darwin",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin-pins": "nixpkgs-darwin-pins",
         "pronto": "pronto",
         "zen-browser": "zen-browser"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -15,6 +15,9 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # Pinned nixpkgs for darwin packages that lack binary cache on newer revs.
+    # Update manually when the package is cached; excluded from automated updates.
+    nixpkgs-darwin-pins.url = "github:nixos/nixpkgs/0726a0ecb6d4e08f6adced58726b95db924cef57";
     flake-parts.url = "github:hercules-ci/flake-parts";
     nix-darwin = {
       url = "github:nix-darwin/nix-darwin/master";

--- a/nix/modules/hosts/aaron/configuration.nix
+++ b/nix/modules/hosts/aaron/configuration.nix
@@ -34,8 +34,8 @@ in
   # Packages pinned to older nixpkgs until binary cache is available.
   # Remove entries once the package has a cached build for aarch64-darwin.
   nixpkgs.overlays = [
-    (final: prev: {
-      deno = nixpkgs-darwin-pins.legacyPackages.aarch64-darwin.deno;
+    (_final: _prev: {
+      inherit (nixpkgs-darwin-pins.legacyPackages.aarch64-darwin) deno;
     })
   ];
 

--- a/nix/modules/hosts/aaron/configuration.nix
+++ b/nix/modules/hosts/aaron/configuration.nix
@@ -2,6 +2,7 @@
   self,
   pkgs,
   lib,
+  nixpkgs-darwin-pins,
   ...
 }:
 let
@@ -29,6 +30,14 @@ in
   };
 
   nixpkgs.hostPlatform = "aarch64-darwin";
+
+  # Packages pinned to older nixpkgs until binary cache is available.
+  # Remove entries once the package has a cached build for aarch64-darwin.
+  nixpkgs.overlays = [
+    (final: prev: {
+      deno = nixpkgs-darwin-pins.legacyPackages.aarch64-darwin.deno;
+    })
+  ];
 
   system = {
     primaryUser = "soft";

--- a/nix/modules/hosts/aaron/configuration.nix
+++ b/nix/modules/hosts/aaron/configuration.nix
@@ -2,7 +2,7 @@
   self,
   pkgs,
   lib,
-  nixpkgs-darwin-pins,
+  # nixpkgs-darwin-pins,
   ...
 }:
 let
@@ -35,7 +35,7 @@ in
   # Remove entries once the package has a cached build for aarch64-darwin.
   nixpkgs.overlays = [
     (_final: _prev: {
-      inherit (nixpkgs-darwin-pins.legacyPackages.aarch64-darwin) deno;
+      # inherit (nixpkgs-darwin-pins.legacyPackages.aarch64-darwin) deno;
     })
   ];
 

--- a/nix/modules/hosts/aaron/configuration.nix
+++ b/nix/modules/hosts/aaron/configuration.nix
@@ -2,7 +2,7 @@
   self,
   pkgs,
   lib,
-  # nixpkgs-darwin-pins,
+  nixpkgs-darwin-pins,
   ...
 }:
 let
@@ -35,7 +35,7 @@ in
   # Remove entries once the package has a cached build for aarch64-darwin.
   nixpkgs.overlays = [
     (_final: _prev: {
-      # inherit (nixpkgs-darwin-pins.legacyPackages.aarch64-darwin) deno;
+      inherit (nixpkgs-darwin-pins.legacyPackages.aarch64-darwin) deno;
     })
   ];
 

--- a/nix/modules/hosts/aaron/default.nix
+++ b/nix/modules/hosts/aaron/default.nix
@@ -9,11 +9,12 @@ let
     nix-index-database
     home-manager
     agenix
+    nixpkgs-darwin-pins
     ;
 in
 {
   flake.darwinConfigurations.aaron = nix-darwin.lib.darwinSystem {
-    specialArgs = { inherit self agenix; };
+    specialArgs = { inherit self agenix nixpkgs-darwin-pins; };
     modules = [
       ./configuration.nix
       nix-index-database.darwinModules.nix-index

--- a/nix/modules/nixos-workstation.nix
+++ b/nix/modules/nixos-workstation.nix
@@ -127,7 +127,6 @@ _: {
             pavucontrol
             playerctl
             slurp
-            telegram-desktop
             usbutils # provides lsusb
             whatsapp-electron
             wl-clipboard

--- a/nix/modules/workstation.nix
+++ b/nix/modules/workstation.nix
@@ -69,6 +69,7 @@ _: {
               signal-desktop
               sox # Voice for claude
               spotify
+              telegram-desktop
               unzip
               yt-dlp
             ];


### PR DESCRIPTION
Automated flake input update.

## Package changes (leod)

```diff
aquamarine: 0.10.0 → 0.11.0, 17.8 KiB
+boringssl: 0.20260413.0 added, 3.4 MiB
chromium: 147.0.7727.101 → 147.0.7727.116
chromium-unwrapped: 147.0.7727.101 → 147.0.7727.116, 11.1 KiB
claude-code: 2.1.112 → 2.1.119, 154.1 MiB
codex: 0.122.0 → 0.125.0, 15.6 MiB
deno: 2.7.12 → 2.7.13, -255.0 KiB
discord: 0.0.130 → 0.0.134, -191.6 KiB
electron: 40.8.5, 41.2.0 → 40.9.2, 41.3.0
electron-unwrapped: 40.8.5, 41.2.0 → 40.9.2, 41.3.0, 360.3 KiB
firefox: -13.0 KiB
firefox-unwrapped: -267.9 KiB
firefoxpwa-unwrapped: -267.9 KiB
fzf: 0.71.0 → 0.72.0, 22.5 KiB
gh: 2.90.0 → 2.91.0, 148.7 KiB
google-chrome: 147.0.7727.101 → 147.0.7727.116, 1.2 MiB
home-manager: 0-unstable-2026-04-14 → 0-unstable-2026-04-24, 102.3 KiB
hypridle: -17.4 KiB
hyprland: -131.4 KiB
hyprlock: -35.6 KiB
hyprpaper: -31.7 KiB
hyprtoolkit: -36.5 KiB
hyprwire: 0.3.0 → 0.3.1, 9.5 KiB
libphonenumber: 9.0.28 → 9.0.29, 25.6 KiB
neovim: 0.12.1 → 0.12.2
neovim-unwrapped: 0.12.1 → 0.12.2, 19.4 KiB
nh: 4.3.1 → 4.3.2
nh-unwrapped: 4.3.1 → 4.3.2, 10.5 KiB
niri: 25.11 → 26.04, -597.0 KiB
nix-index: 0.1.9-unstable-2026-02-05 → 0.1.9-unstable-2026-04-20, 4.4 MiB
nix-index-with-full-db: 0.1.9-unstable-2026-02-05 → 0.1.9-unstable-2026-04-20
nixos-manual: 24.8 KiB
nixos-system-leod: 26.05.20260422.0726a0e → 26.05.20260427.1c3fe55
nss: 3.123 → 3.123.1
ollama: 0.21.0 → 0.21.1, -21.1 KiB
opencode: 1.14.19 → 1.14.25, 377.9 KiB
pnpm: 10.33.0 → 10.33.2, 26.0 KiB
signal-desktop: -2.4 MiB
source: 609.4 KiB
telegram-desktop: 6.7.5 → 6.7.6, 656.6 KiB
tree-sitter-c-neovim: 0.12.1 → 0.12.2
tree-sitter-lua-neovim: 0.12.1 → 0.12.2
tree-sitter-markdown-neovim: 0.12.1 → 0.12.2
tree-sitter-markdown_inline-neovim: 0.12.1 → 0.12.2
tree-sitter-query-neovim: 0.12.1 → 0.12.2
tree-sitter-vim-neovim: 0.12.1 → 0.12.2
tree-sitter-vimdoc-neovim: 0.12.1 → 0.12.2
vimplugin-conform.nvim: 9.1.0-unstable-2026-03-10 → 9.1.0-unstable-2026-04-23
vimplugin-octo.nvim: 0-unstable-2026-04-16 → 0-unstable-2026-04-22, 12.7 KiB
zen: 1.19.9b → 1.19.10b, 56.1 KiB
zen-browser-unwrapped: 1.19.9b → 1.19.10b, 64.3 KiB
```