### PR TITLE
Migrate git worktree scripts to nix pkgs

### DIFF
--- a/nix/modules/workstation.nix
+++ b/nix/modules/workstation.nix
@@ -31,6 +31,8 @@ _: {
               vscode-wrapped
               gen-commit-msg
               git-find-commit
+              git-worktree-add
+              git-worktree-remove
               pm
               pdfshrink
               nixplatforms

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -23,6 +23,8 @@ _: {
         birthdays = pkgs.callPackage ./birthdays { };
         gen-commit-msg = pkgs.callPackage ./gen-commit-msg { inherit self'; };
         git-find-commit = pkgs.callPackage ./git-find-commit { };
+        git-worktree-add = pkgs.callPackage ./git-worktree-add { inherit self'; };
+        git-worktree-remove = pkgs.callPackage ./git-worktree-remove { };
         pm = pkgs.callPackage ./pm { };
         pdfshrink = pkgs.callPackage ./pdfshrink { };
         nixplatforms = pkgs.callPackage ./nixplatforms.nix { };

--- a/nix/pkgs/git-worktree-add/default.nix
+++ b/nix/pkgs/git-worktree-add/default.nix
@@ -1,0 +1,16 @@
+{
+  self',
+  writeShellApplication,
+  coreutils,
+  git,
+}:
+writeShellApplication {
+  name = "git-worktree-add";
+  runtimeInputs = [
+    coreutils
+    git
+    self'.packages.tmux-sessionizer
+  ];
+  inheritPath = false;
+  text = builtins.readFile ./git-worktree-add.sh;
+}

--- a/nix/pkgs/git-worktree-add/git-worktree-add.sh
+++ b/nix/pkgs/git-worktree-add/git-worktree-add.sh
@@ -1,6 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 REPO_NAME=$(basename "$(git remote get-url origin)" .git)
 

--- a/nix/pkgs/git-worktree-remove/default.nix
+++ b/nix/pkgs/git-worktree-remove/default.nix
@@ -1,0 +1,16 @@
+{
+  writeShellApplication,
+  coreutils,
+  git,
+  tmux,
+}:
+writeShellApplication {
+  name = "git-worktree-remove";
+  runtimeInputs = [
+    coreutils
+    git
+    tmux
+  ];
+  inheritPath = false;
+  text = builtins.readFile ./git-worktree-remove.sh;
+}

--- a/nix/pkgs/git-worktree-remove/git-worktree-remove.sh
+++ b/nix/pkgs/git-worktree-remove/git-worktree-remove.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 WORKTREE_PATH="$1"
 
@@ -11,12 +13,10 @@ fi
 
 SESSION_NAME=$(basename "$WORKTREE_PATH")
 
-# Kill tmux session if it exists
 if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
   tmux kill-session -t "$SESSION_NAME"
 fi
 
-# Remove worktree
 git worktree remove "$WORKTREE_PATH"
 
 echo "Cleaned up $SESSION_NAME"


### PR DESCRIPTION
Move git-worktree-add and git-worktree-remove from the stow-style git/ directory into nix/pkgs/ as proper writeShellApplication packages, registered in default.nix and exposed via workstation.nix.

https://claude.ai/code/session_01Cf1BvjrE2ZVG1oUAnFqhay