### PR TITLE
fix: add @admin to trusted-users on darwin (aaron)

### DIFF
--- a/modules/hosts/aaron/configuration.nix
+++ b/modules/hosts/aaron/configuration.nix
@@ -26,6 +26,12 @@ in
   # Determinate Nix manages the daemon and GC; nix-darwin must not conflict.
   nix.enable = false;
 
+  # Determinate Nix ignores nix.settings; it manages /etc/nix/nix.conf itself
+  # and provides /etc/nix/nix.custom.conf for user overrides.
+  environment.etc."nix/nix.custom.conf".text = ''
+    trusted-users = root @admin
+  '';
+
   nixpkgs.hostPlatform = "aarch64-darwin";
 
   networking.hostName = "aaron";


### PR DESCRIPTION
Fixes warnings about untrusted substituters when running nix commands on the aaron machine:

```
warning: ignoring untrusted substituter 'https://nix-community.cachix.org', you are not a trusted user.
warning: ignoring untrusted substituter 'https://soft-nix.cachix.org', you are not a trusted user.
```

Mirrors what `nixos-base.nix` does with `@wheel` for Linux hosts, but uses `@admin` for macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)