### PR TITLE
feat: add global gitignore to git-wrapped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-.direnv
-.DS_Store
-result
-.claude/worktrees

--- a/pkgs/git-wrapped/default.nix
+++ b/pkgs/git-wrapped/default.nix
@@ -33,6 +33,13 @@ let
     ];
     text = builtins.readFile ./git-worktree-remove.sh;
   };
+  systemConfig = pkgs.concatText "gitconfig-system" [
+    ./gitconfig-system
+    (pkgs.writeText "gitconfig-system-excludes" /* gitconfig */ ''
+      [core]
+        excludesFile = ${./gitignore-global}
+    '')
+  ];
 in
 pkgs.symlinkJoin {
   name = "git-wrapped";
@@ -47,7 +54,7 @@ pkgs.symlinkJoin {
   meta.mainProgram = "git";
   postBuild = ''
     wrapProgram $out/bin/git \
-      --set GIT_CONFIG_SYSTEM ${./gitconfig-system} \
+      --set GIT_CONFIG_SYSTEM ${systemConfig} \
       --set GIT_CONFIG_GLOBAL ${userConfig} \
       --prefix PATH : ${lib.makeBinPath deps}
   '';

--- a/pkgs/git-wrapped/gitignore-global
+++ b/pkgs/git-wrapped/gitignore-global
@@ -1,0 +1,1 @@
+**/.claude/settings.local.json

--- a/pkgs/git-wrapped/gitignore-global
+++ b/pkgs/git-wrapped/gitignore-global
@@ -1,1 +1,5 @@
+.direnv
+.DS_Store
+result
 **/.claude/settings.local.json
+**/.claude/worktrees


### PR DESCRIPTION
## Summary

- Adds `pkgs/git-wrapped/gitignore-global` with `.direnv`, `.DS_Store`, `result`, `.claude/settings.local.json`, and `.claude/worktrees`
- Wires it into `GIT_CONFIG_SYSTEM` via `pkgs.concatText`, appending a `core.excludesFile` snippet pointing to the store path
- Removes the now-empty repo-level `.gitignore`

## Test plan

- [ ] `nix build` succeeds
- [ ] `git config core.excludesFile` resolves to the store path after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)