### PR TITLE
feat: bundle plan usage statusLine into claude-code-wrapped

### DIFF
--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -3,6 +3,7 @@
   symlinkJoin,
   makeWrapper,
   claude-code,
+  coreutils,
   jq,
   writeShellApplication,
   writeText,
@@ -10,7 +11,10 @@
 let
   statuslineScript = writeShellApplication {
     name = "claude-plan-usage";
-    runtimeInputs = [ jq ];
+    runtimeInputs = [
+      coreutils
+      jq
+    ];
     inheritPath = false;
     text = ''
       input=$(cat)

--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   symlinkJoin,
   makeWrapper,
   claude-code,
@@ -24,7 +25,7 @@ let
     builtins.toJSON {
       statusLine = {
         type = "command";
-        command = "${statuslineScript}/bin/claude-plan-usage";
+        command = lib.getExe statuslineScript;
       };
     }
   );

--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -16,12 +16,14 @@ let
     [ -n "$week" ] && out="$out 7d:$(printf '%.0f' "$week")%"
     echo "$out"
   '';
-  settingsFile = writeText "claude-settings.json" (builtins.toJSON {
-    statusLine = {
-      type = "command";
-      command = toString statuslineScript;
-    };
-  });
+  settingsFile = writeText "claude-settings.json" (
+    builtins.toJSON {
+      statusLine = {
+        type = "command";
+        command = toString statuslineScript;
+      };
+    }
+  );
 in
 symlinkJoin {
   name = "claude-code-wrapped";

--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -11,6 +11,7 @@ let
   statuslineScript = writeShellApplication {
     name = "claude-plan-usage";
     runtimeInputs = [ jq ];
+    inheritPath = false;
     text = ''
       input=$(cat)
       five=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')

--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -2,7 +2,27 @@
   symlinkJoin,
   makeWrapper,
   claude-code,
+  jq,
+  writeShellScript,
+  writeText,
 }:
+let
+  statuslineScript = writeShellScript "claude-plan-usage" ''
+    input=$(cat)
+    five=$(echo "$input" | ${jq}/bin/jq -r '.rate_limits.five_hour.used_percentage // empty')
+    week=$(echo "$input" | ${jq}/bin/jq -r '.rate_limits.seven_day.used_percentage // empty')
+    out=""
+    [ -n "$five" ] && out="5h:$(printf '%.0f' "$five")%"
+    [ -n "$week" ] && out="$out 7d:$(printf '%.0f' "$week")%"
+    echo "$out"
+  '';
+  settingsFile = writeText "claude-settings.json" (builtins.toJSON {
+    statusLine = {
+      type = "command";
+      command = toString statuslineScript;
+    };
+  });
+in
 symlinkJoin {
   name = "claude-code-wrapped";
   nativeBuildInputs = [ makeWrapper ];
@@ -10,6 +30,7 @@ symlinkJoin {
   meta.mainProgram = "claude";
   postBuild = ''
     wrapProgram $out/bin/claude \
-      --set CLAUDE_CODE_NO_FLICKER 1
+      --set CLAUDE_CODE_NO_FLICKER 1 \
+      --add-flags "--settings ${settingsFile}"
   '';
 }

--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -3,24 +3,28 @@
   makeWrapper,
   claude-code,
   jq,
-  writeShellScript,
+  writeShellApplication,
   writeText,
 }:
 let
-  statuslineScript = writeShellScript "claude-plan-usage" ''
-    input=$(cat)
-    five=$(echo "$input" | ${jq}/bin/jq -r '.rate_limits.five_hour.used_percentage // empty')
-    week=$(echo "$input" | ${jq}/bin/jq -r '.rate_limits.seven_day.used_percentage // empty')
-    out=""
-    [ -n "$five" ] && out="5h:$(printf '%.0f' "$five")%"
-    [ -n "$week" ] && out="$out 7d:$(printf '%.0f' "$week")%"
-    echo "$out"
-  '';
+  statuslineScript = writeShellApplication {
+    name = "claude-plan-usage";
+    runtimeInputs = [ jq ];
+    text = ''
+      input=$(cat)
+      five=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+      week=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+      out=""
+      [ -n "$five" ] && out="5h:$(printf '%.0f' "$five")%"
+      [ -n "$week" ] && out="$out 7d:$(printf '%.0f' "$week")%"
+      echo "$out"
+    '';
+  };
   settingsFile = writeText "claude-settings.json" (
     builtins.toJSON {
       statusLine = {
         type = "command";
-        command = toString statuslineScript;
+        command = "${statuslineScript}/bin/claude-plan-usage";
       };
     }
   );


### PR DESCRIPTION
## Summary

- Adds a `statusLine` script (`claude-plan-usage`) to `claude-code-wrapped` that displays 5-hour and 7-day subscription plan usage percentages at the bottom of the Claude Code UI (e.g. `5h:42% 7d:15%`)
- The script and a settings JSON file are built into the Nix store; the `--settings` flag wires them in at every invocation — no changes to `~/.claude/settings.json`
- Uses `jq` from nixpkgs (pinned via Nix store path in the script) so it doesn't depend on system `jq`

## Test plan

- [ ] Build with `nix build .#claude-code-wrapped`
- [ ] Start a `claude` session and send a message — status bar should show `5h:XX% 7d:XX%` once rate-limit data comes back from the first API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)