### PR TITLE
feat: store Claude config in repo for cross-machine sharing

### DIFF
--- a/pkgs/claude-code-wrapped/config/.gitignore
+++ b/pkgs/claude-code-wrapped/config/.gitignore
@@ -1,0 +1,15 @@
+settings.local.json
+worktrees/
+todos/
+credentials/
+*.log
+history.jsonl
+backups/
+cache/
+file-history/
+daemon*
+session-env/
+sessions/
+telemetry/
+paste-cache/
+shell-snapshots/

--- a/pkgs/claude-code-wrapped/config/projects/-Users-soft-setup/memory/MEMORY.md
+++ b/pkgs/claude-code-wrapped/config/projects/-Users-soft-setup/memory/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory Index
+
+- [Worktree PR workflow](feedback_worktree_pr_workflow.md) — always open a PR from worktree branches, never push/merge to main directly

--- a/pkgs/claude-code-wrapped/config/projects/-Users-soft-setup/memory/feedback_worktree_pr_workflow.md
+++ b/pkgs/claude-code-wrapped/config/projects/-Users-soft-setup/memory/feedback_worktree_pr_workflow.md
@@ -1,0 +1,14 @@
+---
+name: worktree-pr-workflow
+description: "When working in a worktree, always open a PR — never push or merge directly to main"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 9aa6aa36-02a5-4c4a-ace4-baa102eb07e2
+---
+
+When working in a worktree, always open a PR with the changes and let the user decide when to merge. Never commit and push to main directly.
+
+**Why:** User explicitly said so — they want to review and control when things land on main.
+
+**How to apply:** After committing in a worktree branch, create a PR with `gh pr create`. Do not push the worktree branch to main or merge it yourself.

--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -43,6 +43,7 @@ symlinkJoin {
   postBuild = ''
     wrapProgram $out/bin/claude \
       --set CLAUDE_CODE_NO_FLICKER 1 \
+      --set CLAUDE_CONFIG_DIR "$HOME/setup/pkgs/claude-code-wrapped/config" \
       --add-flags "--settings ${settingsFile}"
   '';
 }


### PR DESCRIPTION
## Summary

- Sets `CLAUDE_CONFIG_DIR=~/setup/pkgs/claude-code-wrapped/config` in the `claude-code-wrapped` wrapper
- Memory and user settings now live inside the repo and sync across machines via git
- `.gitignore` in the config dir tracks memory/settings while ignoring ephemeral state (history, sessions, worktrees, etc.)

## Test plan

- [ ] `nix build .#claude-code-wrapped` succeeds
- [ ] After `darwin-rebuild switch`, run `claude --version` and verify `CLAUDE_CONFIG_DIR` is set (`env | grep CLAUDE_CONFIG_DIR`)
- [ ] Confirm memory files appear at `pkgs/claude-code-wrapped/config/projects/-Users-soft-setup/memory/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)