### PR TITLE
feat: show quota reset countdown in statusline

### DIFF
--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -16,11 +16,39 @@ let
     inheritPath = false;
     text = ''
       input=$(cat)
-      five=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
-      week=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+      now=$(date +%s)
+
+      fmt_duration() {
+        local d=$1
+        if [ "$d" -le 0 ]; then
+          echo "now"
+        elif [ "$d" -lt 3600 ]; then
+          echo "$((d / 60))m"
+        elif [ "$d" -lt 86400 ]; then
+          local h=$((d / 3600)) m=$(( (d % 3600) / 60 ))
+          [ "$m" -gt 0 ] && echo "''${h}h''${m}m" || echo "''${h}h"
+        else
+          local dy=$((d / 86400)) h=$(( (d % 86400) / 3600 ))
+          [ "$h" -gt 0 ] && echo "''${dy}d''${h}h" || echo "''${dy}d"
+        fi
+      }
+
+      five_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+      five_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+      week_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+      week_reset=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+
       out=""
-      [ -n "$five" ] && out="5h:$(printf '%.0f' "$five")%"
-      [ -n "$week" ] && out="$out 7d:$(printf '%.0f' "$week")%"
+      if [ -n "$five_pct" ]; then
+        five_str="5h:$(printf '%.0f' "$five_pct")%"
+        [ -n "$five_reset" ] && five_str="$five_str($(fmt_duration $((five_reset - now))))"
+        out="$five_str"
+      fi
+      if [ -n "$week_pct" ]; then
+        week_str="7d:$(printf '%.0f' "$week_pct")%"
+        [ -n "$week_reset" ] && week_str="$week_str($(fmt_duration $((week_reset - now))))"
+        out="$out $week_str"
+      fi
       echo "$out"
     '';
   };


### PR DESCRIPTION
## Summary

- Reads `resets_at` Unix timestamp from the rate limits JSON for both the 5-hour and 7-day windows
- Computes time remaining and formats it as `Xm`, `XhYm`, or `XdYh`
- Appends the countdown in parentheses after each usage percentage

**Example output:** `5h:45%(1h23m) 7d:12%(3d4h)`

## Test plan

- [ ] Build `pkgs.claude-code-wrapped` and verify the script produces expected output
- [ ] Check that missing `resets_at` (e.g. first launch before API response) gracefully omits the countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)