### PR TITLE
feat: show quota reset time in statusline

### DIFF
--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -27,3 +27,5 @@ Run `git alias` to discover available git aliases before running git commands.
 
 After committing on a branch, open a PR with `gh pr create`. Never merge to
 main directly — the user reviews all code and decides when to merge.
+
+Always rebase the branch on main before submitting a PR.

--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -16,6 +16,11 @@ or the comma shorthand `, <package>` rather than skipping the step.
 
 Always format, typecheck, and lint after making a change.
 
+## Testing
+
+Always test that code works before committing. Run the relevant test, build, or
+manual verification step first.
+
 ## Git Workflow
 
 Run `git alias` to discover available git aliases before running git commands.

--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -28,4 +28,4 @@ Run `git alias` to discover available git aliases before running git commands.
 After committing on a branch, open a PR with `gh pr create`. Never merge to
 main directly — the user reviews all code and decides when to merge.
 
-Always rebase the branch on main before submitting a PR.
+Always rebase the branch on origin/main before submitting a PR.

--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -16,23 +16,6 @@ let
     inheritPath = false;
     text = ''
       input=$(cat)
-      now=$(date +%s)
-
-      fmt_duration() {
-        local d=$1
-        if [ "$d" -le 0 ]; then
-          echo "now"
-        elif [ "$d" -lt 3600 ]; then
-          echo "$((d / 60))m"
-        elif [ "$d" -lt 86400 ]; then
-          local h=$((d / 3600)) m=$(( (d % 3600) / 60 ))
-          [ "$m" -gt 0 ] && echo "''${h}h''${m}m" || echo "''${h}h"
-        else
-          local dy=$((d / 86400)) h=$(( (d % 86400) / 3600 ))
-          [ "$h" -gt 0 ] && echo "''${dy}d''${h}h" || echo "''${dy}d"
-        fi
-      }
-
       five_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
       five_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
       week_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
@@ -41,12 +24,12 @@ let
       out=""
       if [ -n "$five_pct" ]; then
         five_str="5h:$(printf '%.0f' "$five_pct")%"
-        [ -n "$five_reset" ] && five_str="$five_str($(fmt_duration $((five_reset - now))))"
+        [ -n "$five_reset" ] && five_str="$five_str($(date -d "@$five_reset" +"%H:%M"))"
         out="$five_str"
       fi
       if [ -n "$week_pct" ]; then
         week_str="7d:$(printf '%.0f' "$week_pct")%"
-        [ -n "$week_reset" ] && week_str="$week_str($(fmt_duration $((week_reset - now))))"
+        [ -n "$week_reset" ] && week_str="$week_str($(date -d "@$week_reset" +"%a %H:%M"))"
         out="$out $week_str"
       fi
       echo "$out"


### PR DESCRIPTION
## Summary

- Reads `resets_at` Unix timestamp from rate limits JSON for both the 5-hour and 7-day windows
- Appends wall-clock reset time in parentheses after each usage percentage
- Uses GNU `date -d` (via coreutils runtimeInput) — no custom duration logic

**Example output:** `5h:45%(14:32) 7d:12%(Thu 09:00)`

## Test plan

- [ ] Build from worktree with `nix run .#claude-code-wrapped` and verify statusline shows reset times

🤖 Generated with [Claude Code](https://claude.com/claude-code)