### PR TITLE
feat: add git branch to statusline

### DIFF
--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -3,6 +3,7 @@
   makeWrapper,
   claude-code,
   coreutils,
+  git,
   jq,
   writeShellApplication,
 }:
@@ -11,6 +12,7 @@ let
     name = "claude-plan-usage";
     runtimeInputs = [
       coreutils
+      git
       jq
     ];
     inheritPath = false;
@@ -22,11 +24,14 @@ let
       week_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
       week_reset=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
 
+      branch=$(git branch --show-current 2>/dev/null)
+
       out="[$model]"
+      [ -n "$branch" ] && out="$out $branch"
       if [ -n "$five_pct" ]; then
         five_str="5h:$(printf '%.0f' "$five_pct")%"
         [ -n "$five_reset" ] && five_str="$five_str($(date -d "@$five_reset" +"%H:%M"))"
-        out="$out $five_str"
+        out="$out | $five_str"
       fi
       if [ -n "$week_pct" ]; then
         week_str="7d:$(printf '%.0f' "$week_pct")%"


### PR DESCRIPTION
## Summary

- Runs `git branch --show-current` and inserts the branch name between model and rate limits
- Silently omitted when not in a git repo
- Adds `git` to `runtimeInputs` so the Nix sandbox has it available
- Output: `[Sonnet] main | 5h:23%(14:30) 7d:41%(Thu 10:00)`

## Test plan

- [ ] Build and verify branch name appears in statusline inside a git repo
- [ ] Verify statusline still works outside a git repo (no branch shown)
- [ ] Verify rate limit separator `|` only appears when rate limits are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)