### PR TITLE
docs: note gh pr merge workaround for git worktrees

### DIFF
--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -39,7 +39,8 @@ Run `git alias` to discover available git aliases before running git commands.
 After committing on a branch, open a PR with `gh pr create`. Never merge to main
 directly — the user reviews all code and decides when to merge.
 
-Always rebase the branch on origin/main before submitting a PR.
+Always rebase on origin/main before presenting a PR for review — both on initial
+`gh pr create` and after any follow-up changes before telling the user it's ready.
 
 Preferred merge strategy is squash merge (`--squash`).
 

--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -49,6 +49,13 @@ Before pushing new commits to a branch, check that its PR has not already been
 merged (`gh pr view <number> --json state`). If it has, start a fresh branch
 from origin/main instead.
 
+When merging a PR from inside a git worktree, `gh pr merge` fails because
+`main` is already checked out in the parent worktree. Use the GitHub API instead:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{N}/merge -X PUT -f merge_method=squash
+```
+
 ## CLAUDE.md Maintenance
 
 Only document project-specific conventions and decisions — not general knowledge


### PR DESCRIPTION
## Summary

Documents that `gh pr merge` fails from inside a git worktree (because `main` is already checked out in the parent worktree) and provides the `gh api` commands to use instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)