### PR TITLE
feat: add session cost to statusline

### DIFF
--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -19,6 +19,7 @@ let
     text = ''
       input=$(cat)
       model=$(echo "$input" | jq -r '.model.display_name')
+      cost=$(echo "$input" | jq -r '.cost.total_cost_usd // empty')
       five_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
       five_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
       week_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
@@ -28,6 +29,7 @@ let
 
       out="[$model]"
       [ -n "$branch" ] && out="$out $branch"
+      [ -n "$cost" ] && out="$out | \$$(printf '%.2f' "$cost")"
       if [ -n "$five_pct" ]; then
         five_str="5h:$(printf '%.0f' "$five_pct")%"
         [ -n "$five_reset" ] && five_str="$five_str($(date -d "@$five_reset" +"%H:%M"))"


### PR DESCRIPTION
## Summary

- Reads `cost.total_cost_usd` from the statusLine JSON input
- Displays it as `$X.XX` between the branch name and rate limit info
- Hidden when absent (e.g. before first API response)

Example output: `[Sonnet 4.6] main | $0.80 | 5h:24%(17:00)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)