### PR TITLE
feat: colorize claude statusline output

### DIFF
--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -27,16 +27,32 @@ let
 
       branch=$(git branch --show-current 2>/dev/null)
 
+      green=$'\033[32m'
+      yellow=$'\033[33m'
+      red=$'\033[31m'
+      reset=$'\033[0m'
+
+      pct_color() {
+        local pct=$1
+        if [ "$pct" -ge 80 ]; then
+          printf '%s' "$red"
+        elif [ "$pct" -ge 50 ]; then
+          printf '%s' "$yellow"
+        fi
+      }
+
       out="[$model]"
-      [ -n "$branch" ] && out="$out $branch"
+      [ -n "$branch" ] && out="$out $green$branch$reset"
       [ -n "$cost" ] && out="$out | \$$(printf '%.2f' "$cost")"
       if [ -n "$five_pct" ]; then
-        five_str="5h:$(printf '%.0f' "$five_pct")%"
+        pct_int=$(printf '%.0f' "$five_pct")
+        five_str="$(pct_color "$pct_int")5h:$pct_int%$reset"
         [ -n "$five_reset" ] && five_str="$five_str($(date -d "@$five_reset" +"%H:%M"))"
         out="$out | $five_str"
       fi
       if [ -n "$week_pct" ]; then
-        week_str="7d:$(printf '%.0f' "$week_pct")%"
+        pct_int=$(printf '%.0f' "$week_pct")
+        week_str="$(pct_color "$pct_int")7d:$pct_int%$reset"
         [ -n "$week_reset" ] && week_str="$week_str($(date -d "@$week_reset" +"%a %H:%M"))"
         out="$out $week_str"
       fi


### PR DESCRIPTION
## Summary

- Branch name rendered in green (matching the CLI prompt)
- Usage percentages traffic-light colored: default (<50%), yellow (50–79%), red (≥80%)
- Model name, separator, and reset times stay in default (dim) color

## Test plan

- [ ] Build `claude-code-wrapped` and check statusline shows green branch
- [ ] Verify usage colors change at the 50% and 80% thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)