### PR TITLE
feat: add context window usage to statusline

### DIFF
--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -20,6 +20,7 @@ let
       input=$(cat)
       model=$(echo "$input" | jq -r '.model.display_name')
       cost=$(echo "$input" | jq -r '.cost.total_cost_usd // empty')
+      ctx_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
       five_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
       five_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
       week_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
@@ -44,6 +45,10 @@ let
       out="[$model]"
       [ -n "$branch" ] && out="$out $green$branch$reset"
       [ -n "$cost" ] && out="$out | \$$(printf '%.2f' "$cost")"
+      if [ -n "$ctx_pct" ]; then
+        pct_int=$(printf '%.0f' "$ctx_pct")
+        out="$out | $(pct_color "$pct_int")ctx:$pct_int%$reset"
+      fi
       if [ -n "$five_pct" ]; then
         pct_int=$(printf '%.0f' "$five_pct")
         five_str="$(pct_color "$pct_int")5h:$pct_int%$reset"

--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -47,7 +47,7 @@ let
       [ -n "$cost" ] && out="$out | \$$(printf '%.2f' "$cost")"
       if [ -n "$ctx_pct" ]; then
         pct_int=$(printf '%.0f' "$ctx_pct")
-        out="$out | $(pct_color "$pct_int")ctx:$pct_int%$reset"
+        out="$out | $(pct_color "$pct_int")$pct_int%$reset"
       fi
       if [ -n "$five_pct" ]; then
         pct_int=$(printf '%.0f' "$five_pct")

--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -47,7 +47,7 @@ let
       [ -n "$cost" ] && out="$out | \$$(printf '%.2f' "$cost")"
       if [ -n "$ctx_pct" ]; then
         pct_int=$(printf '%.0f' "$ctx_pct")
-        out="$out | $(pct_color "$pct_int")$pct_int%$reset"
+        out="$out | $(pct_color "$pct_int")ctx:$pct_int%$reset"
       fi
       if [ -n "$five_pct" ]; then
         pct_int=$(printf '%.0f' "$five_pct")


### PR DESCRIPTION
## Summary

- Adds `ctx:XX%` to the Claude Code statusline, showing current context window usage percentage
- Uses the same color-coding as rate limits (yellow ≥50%, red ≥80%)
- Absent before the first API response (field is empty), consistent with how `used_percentage` behaves

🤖 Generated with [Claude Code](https://claude.ai/claude-code)