### PR TITLE
docs: capture git push and formatter learnings in global CLAUDE.md

### DIFF
--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -28,8 +28,10 @@ rather than skipping the step.
 
 ## Code Style
 
-Always format, typecheck, and lint after making a change. This includes Markdown
-files — format them with `nix run nixpkgs#prettier -- --write <file>`.
+Always format, typecheck, and lint after making a change. Check the conform
+config (`pkgs/neovim-wrapped/plugins/conform/config.lua`) to see which formatter
+applies to a given file type. Markdown files use
+`nix run nixpkgs#prettier -- --write <file>`.
 
 Prefer `kebab-case` for directory names.
 
@@ -64,6 +66,10 @@ always be in separate PRs, even if they are small.
 Before pushing new commits to a branch, check that its PR has not already been
 merged (`gh pr view <number> --json state`). If it has, start a fresh branch
 from origin/main instead.
+
+To push a local branch to a new remote branch of the same name, use
+`git push origin HEAD:<branch-name>`. Avoid `git push -u origin <branch>` on a
+branch that tracks `origin/main` — it will push to main directly.
 
 When merging a PR from inside a git worktree, `gh pr merge` fails because `main`
 is already checked out in the parent worktree. Use the GitHub API instead:


### PR DESCRIPTION
## Summary

- **Code Style**: reference the conform config as the source of truth for which formatter to use per file type
- **Git Workflow**: document that `git push origin HEAD:<branch-name>` must be used to create a new remote branch — using `git push -u origin <branch>` on a branch tracking `origin/main` pushes to main directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)