### PR TITLE
fix: don't abort statusline script outside a git repo

### DIFF
--- a/pkgs/claude-code-wrapped/claude-plan-usage.sh
+++ b/pkgs/claude-code-wrapped/claude-plan-usage.sh
@@ -7,7 +7,7 @@ five_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
 week_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
 week_reset=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
 
-branch=$(git branch --show-current 2>/dev/null)
+branch=$(git branch --show-current 2>/dev/null || true)
 
 green=$'\033[32m'
 yellow=$'\033[33m'


### PR DESCRIPTION
## Summary

- `writeShellApplication` wraps scripts with `set -e -u -o pipefail`, so `git branch --show-current` exiting with code 128 outside a git repo caused the entire statusline script to exit silently — showing nothing on macOS (where Claude is often launched outside a repo).
- Fix: add `|| true` so the branch variable is just empty when not in a repo.

## Test plan

- [ ] Open Claude Code outside a git repo on macOS — statusline should now show model, cost, ctx%, etc.
- [ ] Open Claude Code inside a git repo — branch name still appears as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)