### PR TITLE
docs: document writeShellApplication convention for shell scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,9 @@ agenix (secrets).
 zsh-wrapped, tmux-wrapped, waybar-wrapped, etc.) and custom scripts
 (gen-commit-msg, tmux-sessionizer, pm, brightness-control, etc.).
 
+Shell scripts are packaged with `writeShellApplication` with `inheritPath = false`
+and explicit `runtimeInputs`.
+
 **Secrets** (`secrets/`): agenix-encrypted secrets (Tailscale authkey,
 openai-api-key, gemini-api-key).
 


### PR DESCRIPTION
## Summary

- Documents that shell scripts in `pkgs/` are packaged with `writeShellApplication`, `inheritPath = false`, and explicit `runtimeInputs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)