### PR TITLE
fix: add hue component to home-assistant extraComponents

### DIFF
--- a/modules/home-assistant.nix
+++ b/modules/home-assistant.nix
@@ -5,7 +5,6 @@ _: {
     enable = true;
     extraComponents = [
       "hue"
-      "hue_ble"
       "led_ble"
       "ibeacon"
     ];

--- a/modules/home-assistant.nix
+++ b/modules/home-assistant.nix
@@ -4,6 +4,7 @@ _: {
   services.home-assistant = {
     enable = true;
     extraComponents = [
+      "hue"
       "hue_ble"
       "led_ble"
       "ibeacon"


### PR DESCRIPTION
## Summary
- Adds `"hue"` to `extraComponents` in `modules/home-assistant.nix`
- The Hue Bridge integration requires `aiohue`, which is only pulled in when the `hue` component is declared — `hue_ble` does not include it
- Without this, HA logs: `Setup failed for 'hue': Unable to import component: No module named 'aiohue'`

## Test plan
- [ ] Deploy to Pi (`sudo nixos-rebuild switch`) and verify the Hue integration loads without error in the HA logs