### PR TITLE
feat: run home-assistant on tower

### DIFF
--- a/modules/hosts/tower/configuration.nix
+++ b/modules/hosts/tower/configuration.nix
@@ -3,7 +3,10 @@
 
 { ... }:
 {
-  imports = [ ./hardware-configuration.nix ];
+  imports = [
+    ./hardware-configuration.nix
+    ../../home-assistant.nix
+  ];
 
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;


### PR DESCRIPTION
## Summary
- Adds `home-assistant.nix` to tower's imports, moving HA from Pi to tower
- Tower is already running 24/7 as a web server, so the reliability trade-off is already accepted

## Test plan
- [ ] Deploy to tower (`sudo nixos-rebuild switch`)
- [ ] Verify HA starts and Hue integration loads
- [ ] Re-pair Hue bridge in HA UI if needed (new instance)
- [ ] Open follow-up PR to remove HA from Pi config