### PR TITLE
fix: remove home-assistant from pi

### DIFF
--- a/modules/hosts/pi/configuration.nix
+++ b/modules/hosts/pi/configuration.nix
@@ -12,7 +12,6 @@
 
   imports = [
     ./hardware-configuration.nix
-    ../../home-assistant.nix
   ];
 
   # Use the extlinux boot loader. (NixOS wants to enable GRUB by default)


### PR DESCRIPTION
## Summary
- Removes `home-assistant.nix` from Pi's imports — HA has been verified working on tower (#105)

## Test plan
- [ ] Deploy to Pi (`sudo nixos-rebuild switch`)
- [ ] Confirm HA no longer runs on Pi