### PR TITLE
feat: add auto brightness toggle to circadian lighting

### DIFF
--- a/modules/home-assistant.nix
+++ b/modules/home-assistant.nix
@@ -12,6 +12,12 @@ _: {
       # Includes dependencies for a basic setup
       # https://www.home-assistant.io/integrations/default_config/
       default_config = { };
+      input_boolean = {
+        auto_brightness = {
+          name = "Auto Brightness";
+          icon = "mdi:brightness-auto";
+        };
+      };
       automation = [
         {
           id = "circadian_lighting";
@@ -26,11 +32,21 @@ _: {
               platform = "homeassistant";
               event = "start";
             }
+            {
+              platform = "state";
+              entity_id = "input_boolean.auto_brightness";
+              to = "on";
+            }
           ];
           condition = [
             {
               condition = "state";
               entity_id = "light.home";
+              state = "on";
+            }
+            {
+              condition = "state";
+              entity_id = "input_boolean.auto_brightness";
               state = "on";
             }
           ];


### PR DESCRIPTION
## Summary

- Adds `input_boolean.auto_brightness` — an "Auto Brightness" toggle visible in the Home Assistant UI
- The circadian lighting automation now only runs when this toggle is **on**
- Turning the toggle back on triggers an immediate brightness/color temp update (no need to wait up to 15 min)

## Test plan

- [ ] Deploy to Home Assistant host
- [ ] Verify `input_boolean.auto_brightness` appears in the HA UI
- [ ] Toggle it off and confirm lights are no longer auto-adjusted on the 15-min cycle
- [ ] Toggle it back on and confirm lights update immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)