### PR TITLE
docs: fix stale module and secrets lists in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ agenix (secrets).
 (flake module), `configuration.nix` (host settings), and
 `hardware-configuration.nix` (Linux only).
 
-**Shared modules** (`modules/`):
+**Shared modules** (`modules/`) — the core baseline:
 
 - `base.nix` — common system config (nix settings, SSH keys, zsh, packages)
   applied to all hosts
@@ -37,6 +37,12 @@ agenix (secrets).
 - `nixos-workstation.nix` — NixOS desktop: Niri compositor, GDM, Waybar, audio,
   Bluetooth
 
+Opt-in feature modules expose `flake.nixosModules.<name>` and are imported
+per-host as needed: `server.nix`, `home-assistant.nix`, `darkman.nix`,
+`networkmanager.nix`, `pimsync.nix`. Plumbing modules: `darwinModules.nix`
+(darwin module-type plumbing), `unfree.nix` (`allowedUnfreePackages` option),
+`nix-index.nix`. See `modules/` for the full set.
+
 **Custom packages** (`pkgs/`): wrapped tool configurations (neovim-wrapped,
 zsh-wrapped, tmux-wrapped, waybar-wrapped, etc.) and custom scripts
 (gen-commit-msg, tmux-sessionizer, pm, brightness-control, etc.).
@@ -44,8 +50,9 @@ zsh-wrapped, tmux-wrapped, waybar-wrapped, etc.) and custom scripts
 Shell scripts are packaged with `writeShellApplication` with `inheritPath = false`
 and explicit `runtimeInputs`.
 
-**Secrets** (`secrets/`): agenix-encrypted secrets (Tailscale authkey,
-openai-api-key, gemini-api-key).
+**Secrets** (`secrets/`): agenix-encrypted secrets (Tailscale authkey, API keys,
+Wi-Fi passwords, account passwords, etc.). See `secrets/secrets.nix` for the
+authoritative list.
 
 ### Caches
 


### PR DESCRIPTION
## Summary

The project `CLAUDE.md` enumerated only part of the repo and had drifted:

- **Shared modules** listed 4 of 12 modules. Now keeps the 4 core baseline
  modules and documents the opt-in feature modules (`server`, `home-assistant`,
  `darkman`, `networkmanager`, `pimsync`) and plumbing modules (`darwinModules`,
  `unfree`, `nix-index`), with a pointer to `modules/` for the full set.
- **Secrets** named 3 of 9 secrets. Replaced the enumeration with a pointer to
  `secrets/secrets.nix` (the authoritative list) so it can't go stale again.

This also brings the file in line with its own "don't document derivable,
drift-prone facts" maintenance rule.

## Test plan

- [x] Documentation-only change; module/secret references verified against
      `modules/` and `secrets/` in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)