### PR TITLE
feat(neovim): ignore .claude/worktrees in telescope

### DIFF
--- a/pkgs/neovim-wrapped/plugins/telescope/config.lua
+++ b/pkgs/neovim-wrapped/plugins/telescope/config.lua
@@ -12,7 +12,13 @@ vim.api.nvim_create_autocmd("User", {
 
 require("telescope").setup({
 	defaults = {
-		file_ignore_patterns = { "node_modules", "%.git%/", "package%-lock.json", "pnpm%-lock.yaml" },
+		file_ignore_patterns = {
+			"node_modules",
+			"%.git%/",
+			"%.claude%/worktrees%/",
+			"package%-lock.json",
+			"pnpm%-lock.yaml",
+		},
 	},
 	pickers = {
 		find_files = {


### PR DESCRIPTION
## What

Add `.claude/worktrees/` to telescope's `file_ignore_patterns` so files from git worktrees no longer appear in pickers.

## Why

When working from the repo root, telescope's `find_files` (`<C-p>`/`<leader>ff`), grep, and the custom `multigrep` picker (`<leader>fg`) were surfacing all the code inside `.claude/worktrees/` — duplicate copies of the repo.

## How

Single entry added to `defaults.file_ignore_patterns`. This list is applied in telescope's `Picker:_process_result` for **every** picker (it falls back to the global default), so it covers find_files, grep_string, live_grep, and the custom multigrep alike — even though those run with `--hidden`.

## Testing

- `stylua` formatting clean; `luajit loadfile` syntax check passes.
- Pattern verified against sample paths: `.claude/worktrees/...` (relative + absolute) ignored; normal repo files and `.claude/settings.json` kept.
- Built `neovim-wrapped` from this branch and confirmed in a live nvim session that worktree files no longer appear in `<C-p>` or `<leader>fg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)