### PR TITLE
docs: record session learnings on testing Nix package changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,13 @@ Personal Cachix: `soft-nix.cachix.org`. Also uses `nix-community.cachix.org`.
   `tmux-sessionizer`
 - Shell: zsh; terminal: Ghostty
 
+### Testing wrapped package changes
+
+The `*-wrapped` packages bake their config into the Nix store, so editing a
+config file (e.g. a neovim plugin's `config.lua`) does not affect the installed
+binary until a system rebuild. To test a change in isolation, run just that
+package from the flake — e.g. `nix run ".#neovim-wrapped" -- <file-or-dir>`.
+
 ### neovim-wrapped plugin conventions
 
 Each plugin is a directory under `pkgs/neovim-wrapped/plugins/` with a

--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -36,6 +36,11 @@ source/implementation. Don't rely on only one of these.
 If a needed tool is not installed on the system, use `nix run nixpkgs#<package>`
 rather than skipping the step.
 
+To verify a change, either build it (`nix build`) or run it with a test
+parameter (`nix run <program> -- --test-param`) — both are fine. But when
+handing the user a command to execute themselves, prefer the simplest invocation
+(e.g. `nix run` over `nix build` followed by `./result/bin/...`).
+
 ## Code Style
 
 Always format, typecheck, and lint after making a change. Check the conform


### PR DESCRIPTION
## What

Two small CLAUDE.md additions capturing learnings from the telescope-ignore-worktrees session (PR #114).

- **Project `CLAUDE.md`** — note that `*-wrapped` packages bake their config into the Nix store, so a config edit doesn't affect the installed binary until a system rebuild; test a change in isolation with `nix run ".#neovim-wrapped" -- <file-or-dir>`.
- **Global `CLAUDE.md`** (`pkgs/claude-code-wrapped/config/CLAUDE.md`) — verify a change via either `nix build` or `nix run … --test-param`; when handing the user a command to run themselves, prefer the simplest invocation (`nix run` over build-then-execute).

## Why

During PR #114 the non-obvious bit was that editing a wrapped package's config has no effect until rebuild, and that a single package can be built/run in isolation from the flake. Recording it so future sessions don't suggest a full rebuild for a one-line tweak.

## Notes

Diff is intentionally minimal — only the two new blocks, wrapped to prettier's width. Pre-existing prettier non-compliance elsewhere in these files was left untouched to keep this PR atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)