### PR TITLE
fix: disable Firefox/Zen Wayland fractional scaling

### DIFF
--- a/lib/browser-config.nix
+++ b/lib/browser-config.nix
@@ -36,5 +36,10 @@
   sharedSettings = {
     "browser.ctrlTab.sortByRecentlyUsed" = true;
     "media.videocontrols.picture-in-picture.enable-when-switching-tabs.enabled" = true;
+    # Render at integer scale and let the compositor downscale. Firefox's own
+    # Wayland fractional scaling triggers a popup-grab bug under Niri where
+    # right-click menus and extension popups stop opening after a while, until
+    # the browser is restarted (https://bugzilla.mozilla.org/show_bug.cgi?id=1849109).
+    "widget.wayland.fractional-scale.enabled" = false;
   };
 }


### PR DESCRIPTION
## Problem

On `tower` (Niri/Wayland), both Zen and Firefox develop a bug where, after a while of use, clicks that open **popups stop working** — specifically right-click context menus and the extensions panel — while ordinary clicks keep working. The only fix is restarting the browser.

## Root cause

These are Wayland *popup grabs*. Both browsers run native Wayland (`MOZ_ENABLE_WAYLAND=1`) on a 4K display at **fractional scale 1.25**. Firefox's own fractional-scaling support (`widget.wayland.fractional-scale.enabled`, on by default) has a long-standing popup-grab bug under wlroots-style compositors — see [Mozilla bug 1849109](https://bugzilla.mozilla.org/show_bug.cgi?id=1849109), *"Context menu broken with widget.wayland.fractional-scale.enabled"*. The grab state degrades over the session until a restart re-establishes the Wayland seat binding. Niri's `GL_INVALID_VALUE … width 6144 > 6124` log errors corroborate fractional-scale rounding involvement.

That it affects **both** browsers identically rules out a profile/extension cause and points at the shared Mozilla/GTK platform layer.

## Fix

Set `widget.wayland.fractional-scale.enabled = false` in the shared browser prefs. The browser then renders at integer 2× and lets Niri downscale to 1.25 — sidestepping the bug class, at the cost of marginally softer text (negligible on 4K). Applies to both browsers via `lib/browser-config.nix`.

## Testing

- `nix build .#firefox-wrapped .#zen-browser-wrapped` succeeds.
- Confirmed `lockPref("widget.wayland.fractional-scale.enabled", false);` is baked into both wrappers' `mozilla.cfg`.
- Real-world verification is multi-day (the bug is intermittent); will watch over the coming days after rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)