### PR TITLE
feat: force-install Tactiq Chrome extension via managed policies

### DIFF
--- a/modules/hosts/aaron/configuration.nix
+++ b/modules/hosts/aaron/configuration.nix
@@ -16,6 +16,12 @@ let
 
   inherit (pkgs.stdenv.hostPlatform) system;
   inherit (self.packages.${system}) zsh-wrapped;
+
+  chromePolicies = pkgs.writeText "chrome-policies.json" (builtins.toJSON {
+    ExtensionInstallForcelist = [
+      "bfbogjkneaangbdaafblgfnbpaapmnlb;https://clients2.google.com/service/update2/crx"
+    ];
+  });
 in
 {
   allowedUnfreePackages = [
@@ -71,6 +77,11 @@ in
 
   system = {
     primaryUser = "soft";
+
+    activationScripts.chromePolicies.text = ''
+      mkdir -p "/Library/Application Support/Google/Chrome/policies/managed"
+      cp ${chromePolicies} "/Library/Application Support/Google/Chrome/policies/managed/nix.json"
+    '';
 
     activationScripts.postActivation.text = ''
       ln --symbolic --force --no-dereference /Users/soft/setup /etc/nix-darwin

--- a/modules/nixos-workstation.nix
+++ b/modules/nixos-workstation.nix
@@ -158,6 +158,10 @@ _: {
         };
 
         hyprlock.enable = true;
+
+        chromium.extraOpts.ExtensionInstallForcelist = [
+          "bfbogjkneaangbdaafblgfnbpaapmnlb;https://clients2.google.com/service/update2/crx"
+        ];
       };
 
       home-manager.users.soft = self.homeModules.linux;


### PR DESCRIPTION
## Summary

- **NixOS** (chromium): adds `programs.chromium.extraOpts.ExtensionInstallForcelist` in `nixos-workstation.nix`
- **macOS** (google-chrome): writes a Chrome managed policy JSON file at `/Library/Application Support/Google/Chrome/policies/managed/nix.json` via a nix-darwin activation script; the policy file is generated with `pkgs.writeText` + `builtins.toJSON`

Extension ID: `bfbogjkneaangbdaafblgfnbpaapmnlb` (Tactiq, from the Chrome Web Store)