### PR TITLE
revert: undo Tactiq extension (#117)

### DIFF
--- a/modules/hosts/aaron/configuration.nix
+++ b/modules/hosts/aaron/configuration.nix
@@ -16,12 +16,6 @@ let
 
   inherit (pkgs.stdenv.hostPlatform) system;
   inherit (self.packages.${system}) zsh-wrapped;
-
-  chromePolicies = pkgs.writeText "chrome-policies.json" (builtins.toJSON {
-    ExtensionInstallForcelist = [
-      "bfbogjkneaangbdaafblgfnbpaapmnlb;https://clients2.google.com/service/update2/crx"
-    ];
-  });
 in
 {
   allowedUnfreePackages = [
@@ -77,11 +71,6 @@ in
 
   system = {
     primaryUser = "soft";
-
-    activationScripts.chromePolicies.text = ''
-      mkdir -p "/Library/Application Support/Google/Chrome/policies/managed"
-      cp ${chromePolicies} "/Library/Application Support/Google/Chrome/policies/managed/nix.json"
-    '';
 
     activationScripts.postActivation.text = ''
       ln --symbolic --force --no-dereference /Users/soft/setup /etc/nix-darwin

--- a/modules/nixos-workstation.nix
+++ b/modules/nixos-workstation.nix
@@ -158,10 +158,6 @@ _: {
         };
 
         hyprlock.enable = true;
-
-        chromium.extraOpts.ExtensionInstallForcelist = [
-          "bfbogjkneaangbdaafblgfnbpaapmnlb;https://clients2.google.com/service/update2/crx"
-        ];
       };
 
       home-manager.users.soft = self.homeModules.linux;


### PR DESCRIPTION
Reverts the premature merge of #117. The PR had unaddressed review comments.