### PR TITLE
feat: force-install Tactiq Chrome extension via managed policies

### DIFF
--- a/lib/browser-config.nix
+++ b/lib/browser-config.nix
@@ -33,6 +33,12 @@
     };
   };
 
+  sharedChromeExtraOpts = {
+    ExtensionInstallForcelist = [
+      "bfbogjkneaangbdaafblgfnbpaapmnlb;https://clients2.google.com/service/update2/crx"
+    ];
+  };
+
   sharedSettings = {
     "browser.ctrlTab.sortByRecentlyUsed" = true;
     "media.videocontrols.picture-in-picture.enable-when-switching-tabs.enabled" = true;

--- a/modules/hosts/aaron/configuration.nix
+++ b/modules/hosts/aaron/configuration.nix
@@ -16,6 +16,9 @@ let
 
   inherit (pkgs.stdenv.hostPlatform) system;
   inherit (self.packages.${system}) zsh-wrapped;
+
+  browserConfig = import (self + /lib/browser-config.nix) { inherit lib; };
+  chromePolicies = pkgs.writeText "chrome-policies.json" (builtins.toJSON browserConfig.sharedChromeExtraOpts);
 in
 {
   allowedUnfreePackages = [
@@ -71,6 +74,11 @@ in
 
   system = {
     primaryUser = "soft";
+
+    activationScripts.chromePolicies.text = ''
+      mkdir -p "/Library/Application Support/Google/Chrome/policies/managed"
+      cp ${chromePolicies} "/Library/Application Support/Google/Chrome/policies/managed/nix.json"
+    '';
 
     activationScripts.postActivation.text = ''
       ln --symbolic --force --no-dereference /Users/soft/setup /etc/nix-darwin

--- a/modules/hosts/aaron/configuration.nix
+++ b/modules/hosts/aaron/configuration.nix
@@ -18,7 +18,9 @@ let
   inherit (self.packages.${system}) zsh-wrapped;
 
   browserConfig = import (self + /lib/browser-config.nix) { inherit lib; };
-  chromePolicies = pkgs.writeText "chrome-policies.json" (builtins.toJSON browserConfig.sharedChromeExtraOpts);
+  chromePolicies = pkgs.writeText "chrome-policies.json" (
+    builtins.toJSON browserConfig.sharedChromeExtraOpts
+  );
 in
 {
   allowedUnfreePackages = [

--- a/modules/nixos-workstation.nix
+++ b/modules/nixos-workstation.nix
@@ -8,6 +8,7 @@ _: {
     }:
     let
       inherit (pkgs.stdenv.hostPlatform) system;
+      browserConfig = import (self + /lib/browser-config.nix) { inherit lib; };
     in
     {
       imports = [
@@ -158,6 +159,8 @@ _: {
         };
 
         hyprlock.enable = true;
+
+        chromium.extraOpts = browserConfig.sharedChromeExtraOpts;
       };
 
       home-manager.users.soft = self.homeModules.linux;


### PR DESCRIPTION
Replaces #117 (which was accidentally merged with unaddressed review comments).

## Changes

- **`lib/browser-config.nix`**: adds `sharedChromeExtraOpts` with the Tactiq extension ID — single source of truth, alongside the existing Firefox `sharedPolicies`
- **`modules/nixos-workstation.nix`**: `programs.chromium.extraOpts = browserConfig.sharedChromeExtraOpts`
- **`modules/hosts/aaron/configuration.nix`**: activation script writes a Chrome managed policy JSON to `/Library/Application Support/Google/Chrome/policies/managed/nix.json`, generated via `pkgs.writeText` + `builtins.toJSON`

## Open question (comment 3)

The activation script on darwin is still present — I couldn't find a better mechanism. See my reply on the original PR #117 for the full investigation. Happy to test the `~/Library/...` home-manager path if you want to explore that.