### PR TITLE
docs: document Nix philosophy — no home-manager, prefer -wrapped

### DIFF
--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -23,6 +23,12 @@ Agentur für Arbeit. Has AXA private liability insurance (Privathaftpflicht).
 Do not use the file-based memory system. Instead, write learnings and context
 into this global CLAUDE.md or the relevant project's CLAUDE.md.
 
+## Nix Philosophy
+
+Does not like home-manager and is actively removing it from the setup piece by
+piece. Never suggest home-manager as a solution. Prefers the `-wrapped` pattern
+for configuring programs, and darwin/nixos modules for everything else.
+
 ## Working Style
 
 Work on one thing at a time. When a task naturally leads to a follow-up (e.g.
@@ -86,7 +92,8 @@ After merging, delete the remote branch with
 Keep PRs small and atomic — one logical change per PR. Unrelated changes must
 always be in separate PRs, even if they are small.
 
-For complex features that naturally split into layers, use stacked PRs: each PR builds on the previous one.
+For complex features that naturally split into layers, use stacked PRs: each PR
+builds on the previous one.
 
 **IMPORTANT:** Before pushing new commits to a branch, always check that its PR
 has not already been merged (`gh pr view <number> --json state`). If it has,

--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -87,7 +87,8 @@ before reporting the task as done.
 Before merging, always fetch and read all review comments — never merge with
 open threads. Reply to every comment: if applying a suggestion without anything
 to add, say so explicitly. The user uses Conventional Comments to signal intent
-(e.g. `**issue:**`, `**question:**`, `**suggestion:**`).
+(e.g. `**issue:**`, `**question:**`, `**suggestion:**`). "Reviewed" does not
+mean approved — always check for open comments before merging.
 
 Preferred merge strategy is squash merge (`--squash`).
 

--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -26,8 +26,8 @@ into this global CLAUDE.md or the relevant project's CLAUDE.md.
 ## Nix Philosophy
 
 Does not like home-manager and is actively removing it from the setup piece by
-piece. Never suggest home-manager as a solution. Prefers the `-wrapped` pattern
-for configuring programs, and darwin/nixos modules for everything else.
+piece. Home-manager should be a last resort — prefer the `-wrapped` pattern for
+configuring programs and darwin/nixos modules for everything else.
 
 ## Working Style
 

--- a/pkgs/claude-code-wrapped/config/CLAUDE.md
+++ b/pkgs/claude-code-wrapped/config/CLAUDE.md
@@ -84,6 +84,11 @@ After opening a PR, always check its status
 (`gh pr view --json state,mergeStateStatus`) and resolve any merge conflicts
 before reporting the task as done.
 
+Before merging, always fetch and read all review comments — never merge with
+open threads. Reply to every comment: if applying a suggestion without anything
+to add, say so explicitly. The user uses Conventional Comments to signal intent
+(e.g. `**issue:**`, `**question:**`, `**suggestion:**`).
+
 Preferred merge strategy is squash merge (`--squash`).
 
 After merging, delete the remote branch with


### PR DESCRIPTION
Documents the preference to avoid home-manager (actively being removed from the setup) and favour the `-wrapped` pattern and darwin/nixos modules instead.