### PR TITLE
feat: inject GitHub bot token into claude-code-wrapped via agenix

### DIFF
--- a/modules/workstation.nix
+++ b/modules/workstation.nix
@@ -86,6 +86,10 @@ _: {
           file = ../secrets/gemini-api-key.age;
           owner = "soft";
         };
+        age.secrets.github-bot-token = {
+          file = ../secrets/github-bot-token.age;
+          owner = "soft";
+        };
 
         fonts.packages = with pkgs; [ nerd-fonts.fira-code ];
 

--- a/modules/workstation.nix
+++ b/modules/workstation.nix
@@ -78,17 +78,19 @@ _: {
           in
           inputPackages ++ customPackages ++ externalPackages;
 
-        age.secrets.openai-api-key = {
-          file = ../secrets/openai-api-key.age;
-          owner = "soft";
-        };
-        age.secrets.gemini-api-key = {
-          file = ../secrets/gemini-api-key.age;
-          owner = "soft";
-        };
-        age.secrets.github-bot-token = {
-          file = ../secrets/github-bot-token.age;
-          owner = "soft";
+        age.secrets = {
+          openai-api-key = {
+            file = ../secrets/openai-api-key.age;
+            owner = "soft";
+          };
+          gemini-api-key = {
+            file = ../secrets/gemini-api-key.age;
+            owner = "soft";
+          };
+          github-bot-token = {
+            file = ../secrets/github-bot-token.age;
+            owner = "soft";
+          };
         };
 
         fonts.packages = with pkgs; [ nerd-fonts.fira-code ];

--- a/pkgs/claude-code-wrapped/default.nix
+++ b/pkgs/claude-code-wrapped/default.nix
@@ -28,6 +28,7 @@ symlinkJoin {
     wrapProgram $out/bin/claude \
       --set CLAUDE_CODE_NO_FLICKER 1 \
       --run 'export CLAUDE_CONFIG_DIR="$HOME/setup/pkgs/claude-code-wrapped/config"' \
+      --run 'export GITHUB_TOKEN="$(cat /run/agenix/github-bot-token 2>/dev/null || true)"' \
       --prefix PATH : ${statuslineScript}/bin
   '';
 }

--- a/secrets/github-bot-token.age
+++ b/secrets/github-bot-token.age
@@ -1,0 +1,9 @@
+age-encryption.org/v1
+-> ssh-ed25519 S8sCAA emk6nqFs0vI8cKQCupu0dkwfwYMQuvclfwLF4wLZZ18
+3fgW9yMpawJpICCYqrwSCLsnEeVg+FPpvT1b42aoGqo
+-> ssh-ed25519 bwK7fw 5WNk0WRPR7WWW8nlpYI4thg7mzDaYtK5Fzv+kZueews
+lRwt4DCAPU9oMM8iEsAYrepWyHe37Z6L0jPcCwW05kQ
+-> ssh-ed25519 czuyag NBTC/Gye7PKcWN7ORiet0P7fRn0VGxxsZlGFjS/DcR8
+ewLk8ZBDe+oOvLKPrwm5tsUFeqxz86KFJ5hllsA0rjc
+--- yZ1W6I54olfDIHV9/m+zdUZuS93hd5/amzyP7zbMD74
+¨Ÿp†â²ÙäŽI&¤ÔUR¬ë[î•á˜„õÒÍBÊ%èNmŒ,¶€€+Žañmzp´%û9(3Kˆ|95zp"{¤y3S

--- a/secrets/github-bot-token.age
+++ b/secrets/github-bot-token.age
@@ -1,9 +1,0 @@
-age-encryption.org/v1
--> ssh-ed25519 S8sCAA emk6nqFs0vI8cKQCupu0dkwfwYMQuvclfwLF4wLZZ18
-3fgW9yMpawJpICCYqrwSCLsnEeVg+FPpvT1b42aoGqo
--> ssh-ed25519 bwK7fw 5WNk0WRPR7WWW8nlpYI4thg7mzDaYtK5Fzv+kZueews
-lRwt4DCAPU9oMM8iEsAYrepWyHe37Z6L0jPcCwW05kQ
--> ssh-ed25519 czuyag NBTC/Gye7PKcWN7ORiet0P7fRn0VGxxsZlGFjS/DcR8
-ewLk8ZBDe+oOvLKPrwm5tsUFeqxz86KFJ5hllsA0rjc
---- yZ1W6I54olfDIHV9/m+zdUZuS93hd5/amzyP7zbMD74
-¨Ÿp†â²ÙäŽI&¤ÔUR¬ë[î•á˜„õÒÍBÊ%èNmŒ,¶€€+Žañmzp´%û9(3Kˆ|95zp"{¤y3S

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -10,6 +10,11 @@ let
     leod
     pi
   ];
+  allWorkstations = [
+    tower
+    leod
+    aaron
+  ];
   allMachines = allLinux ++ [ aaron ];
 in
 {
@@ -23,4 +28,5 @@ in
   "soft-password.age".publicKeys = allLinux;
   # TODO: Restrict to relevant machines
   "ddclient-password-etiennerobert-com.age".publicKeys = allLinux;
+  "github-bot-token.age".publicKeys = allWorkstations;
 }


### PR DESCRIPTION
## Summary

- Adds `allWorkstations` group to `secrets/secrets.nix` (tower, leod, aaron — excludes pi)
- Adds `github-bot-token` agenix secret scoped to workstations
- Injects it as `GITHUB_TOKEN` at claude launch via `wrapProgram --run`, so `gh` inside Claude Code sessions uses the bot account

## Branch protection (done separately via API)

- Force pushes: blocked
- Branch deletion: blocked
- Required PRs: 1 approval required, not enforced on admins (you can still push directly)
- Linear history: required (enforces squash/rebase merges)

## Remaining step

After creating the bot GitHub account and PAT, run:
```bash
cd ~/setup/secrets && agenix -e github-bot-token.age
```
Then add the bot account as a collaborator with Write access on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)