### PR TITLE
docs: add TODO for adding user SSH keys as agenix recipients

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,22 @@
+# TODO
+
+## Add user SSH keys as agenix recipients on dev machines
+
+Add Étienne's personal SSH public keys (one per dev machine: aaron, tower, leod)
+as agenix recipients so secrets can be decrypted without sudo.
+
+**Context:** Currently only machine host keys are recipients in
+`secrets/secrets.nix`. Adding user keys is a standard agenix pattern — machine
+keys handle deployment, user keys handle dev/editing workflows. This also allows
+Claude Code agents to decrypt secrets without needing sudo.
+
+**Steps:**
+
+1. Collect `~/.ssh/id_ed25519.pub` from each dev machine (aaron, tower, leod)
+2. Add to `secrets/secrets.nix` as `softAaron` / `softTower` / `softLeod`,
+   grouped into `allSoftKeys`
+3. Add `allSoftKeys` to recipients of dev-facing secrets: `github-bot-token`,
+   `openai-api-key`, `gemini-api-key` — skip system secrets (wifi passwords,
+   `soft-password`, `tailscale-authkey`)
+4. Re-encrypt affected secrets with `agenix -r`
+5. Open a PR


### PR DESCRIPTION
Tracks the follow-up task of adding user SSH public keys as agenix recipients on dev machines, so secrets can be decrypted without sudo (useful for Claude Code agents and local dev workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)