### PR TITLE
ci: upgrade peter-evans/create-pull-request to v8

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -22,7 +22,7 @@ jobs:
         run: nix flake update --accept-flake-config
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PAT }}
           commit-message: "chore: update flake inputs"


### PR DESCRIPTION
## Summary

- Bumps `peter-evans/create-pull-request` from v7 to v8 in the `update-flake` workflow
- v7 uses Node.js 20, which GitHub Actions is deprecating (forced Node.js 24 default from June 2 2026, Node.js 20 removed September 16 2026)

## Test plan

- [ ] No functional change — action interface is compatible between v7 and v8

🤖 Generated with [Claude Code](https://claude.com/claude-code)